### PR TITLE
Dynamic missing key error

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -11,11 +11,13 @@ if TYPE_CHECKING:
     from .jira_options import JiraOptions
 
 class JiraClient:
-    def __init__(self, jira_option: 'JiraOptions', auth: 'JiraAuth'):
+    def __init__(self, jira_option: 'JiraOptions', auth: 'JiraAuth',
+                 no_cache: bool = False):
         self.options = jira_option
         self.auth = auth.auth
         self.no_verify_ssl = auth.no_verify_ssl
         self.project_name = jira_option.project
+        self._no_cache = no_cache
         self.requests_kwargs = {
             'auth': self.auth,
             'headers': {'Content-Type': 'application/json'},
@@ -66,6 +68,8 @@ class JiraClient:
         self.write_to_cache(f'issues/{key}.json', json.dumps(data))
 
     def get_issue_from_cache(self, key: str):
+        if self._no_cache:
+            return
         issue_data = self.get_from_cache(f'issues/{key}.json')
         if issue_data:
             return json.loads(issue_data)

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -3,6 +3,16 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from jira_client import JiraClient
 
+def process_key(key: str):
+    split_key = key.split('-')
+    match split_key:
+        case (s,):
+            raise NotImplementedError(f'Key: {s}')
+        case (project, task_no):
+            return (project, task_no)
+        case _:
+            NotImplementedError(f'Key: {key}')
+
 class JiraIssues:
     allowed_types = {'Story', 'Sub-Task', 'Epic', 'Bug', 'Task'}
 

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -59,9 +59,17 @@ class JiraIssues:
         (project_from_key, task_no_from_key) = process_key(key, exception)
         match exception.response.reason:
             case "Not Found":
-                if self.client.options.project not in key:
+                if (' ' in key):
                     raise ValueError(
-                        f'The requested issue does not exists. Note that the '
+                        f'Whitespace in key is not allowed ("{key}")'
+                    ) from exception
+                elif (not task_no_from_key.isnumeric()):
+                    raise ValueError(
+                        f'Issue number "{task_no_from_key}" in key "{key}" must be numeric'
+                    ) from exception
+                elif self.client.options.project not in key:
+                    raise ValueError(
+                        f'The requested issue does not exist. Note that the '
                         f'provided key "{key}" does not appear to match '
                         f'your configured project "{self.client.options.project}"'
                     ) from exception

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -2,6 +2,7 @@ import pytest
 import os
 from mantis.jira import JiraClient, JiraAuth
 import requests
+from unittest.mock import patch
 
 @pytest.fixture
 def fake_jira(opts_from_fake_cli, mock_get_request):
@@ -14,6 +15,21 @@ def test_JiraIssuesGetFake(fake_jira):
     task_1 = fake_jira.issues.get('TASK-1')
     assert task_1.get('key') == 'TASK-1'
     assert task_1.get('fields') == {'status': {'name': 'resolved'}}
+
+def test_JiraIssuesGetNonExistent(jira_client_from_fake_cli):
+    jira_client_from_fake_cli._no_cache = True
+    _mock_response = requests.models.Response()
+    _mock_response.status_code = 404
+    _mock_response.reason = "Not Found"
+    with patch("requests.get", return_value=_mock_response):
+        with pytest.raises(ValueError, match=('The issue "TEST-999" does not '
+                           'exists in the project "TEST"')):
+            jira_client_from_fake_cli.issues.get('TEST-999')
+        with pytest.raises(ValueError, match="The requested issue does not exists."):
+            jira_client_from_fake_cli.issues.get('NONEXISTENT-1')
+        with pytest.raises(NotImplementedError, match=('Partial keys are not supported. '
+                           'Please provide the full key for your issue: "PROJ-11"')):
+            jira_client_from_fake_cli.issues.get('11')
 
 @pytest.mark.skipif(not os.path.exists("options.toml"), reason='File "options.toml" does not exist')
 @pytest.mark.skipif(not os.getenv('EXECUTE_SKIPPED'), reason="This is a live test against the Jira api")


### PR DESCRIPTION
When calling `jira.issues.get(issue_no)`, a 404 response might be encountered for several different reasons. We can rely on the passed `key` argument and simple heuristics to identify a number of user errors.
- Passing just the issue number, leaving out the project identifier (this might be supported in the future): `99` instead of `PROJ-99`.
- Malformed key with more than one hyphen: `PROJ-99-B`
- Malformed key containing spaces: `PROJ-99 `
- etc.