### PR TITLE
Write markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 options.toml
 
+/drafts/
+

--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ from pprint import pprint
 
 from mantis.jira import JiraClient, JiraOptions, JiraAuth, parse_args
 
+from mantis.drafts import Draft
+
 if __name__ == '__main__':
     jira_options = JiraOptions(parse_args(), 'options.toml')
     auth = JiraAuth(jira_options)
@@ -27,6 +29,7 @@ if __name__ == '__main__':
             key = issue.get('key', 'N/A')
             title = issue.get('fields', {}).get('summary')
             print(f'[{key}] {title}')
+            draft = Draft(issue)
     elif jira_options.action == 'get-project-keys':
         print('Dumped field values for:')
         pprint(jira.get_project_keys())

--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -2,13 +2,14 @@ from pathlib import Path
 
 from typing import TYPE_CHECKING
 
-from ..md_to_jira import j2m, m2j
+# To-do: Create converter for Jira syntax to markdown.
+j2m = lambda x: x
 
 if TYPE_CHECKING:
-    from jira import JiraIssues
+    from mantis.jira import JiraIssues, JiraIssue
 
 class Draft:
-    def __init__(self, issue: 'JiraIssues', drafts_dir: Path = None) -> None:
+    def __init__(self, issue: 'JiraIssue', drafts_dir: Path = None) -> None:
         if not drafts_dir:
             drafts_dir = Path('drafts')
         self.dir = drafts_dir
@@ -21,18 +22,18 @@ class Draft:
         # key = json_payload.get('key')
         assert key, 'No key in issue'
         assert len(key) < 20, f'The length of the key is suspeciously long: "{key[:20]}..."'
-        project = self.issue.get('fields', {}).get('project').get('key')
+        # project = self.issue.get('fields', {}).get('project', {}).get('key')
         parent = self.issue.get('fields', {}).get('parent')
         summary = self.issue.get('fields', {}).get('summary')
-        issuetype = self.issue.get('fields', {}).get('issuetype').get('name')
-        assignee = self.issue.get('fields', {}).get('assignee').get('displayName')
+        issuetype = self.issue.get('fields', {}).get('issuetype', {}).get('name')
+        assignee = self.issue.get('fields', {}).get('assignee', {}).get('displayName')
         description = self.issue.get('fields', {}).get('description')
 
         with open(self.dir / (key+'.md'), 'w') as f:
-            # f.write(f'[{key}] {title}')
-            f.write(f'---')
+            f.write(f'---\n')
+            f.write(f'header: [{key}] {summary}\n')
             f.write(f'ignore: True\n')
-            f.write(f'project: {project}\n')
+            # f.write(f'project: {project}\n')
             f.write(f'parent: {parent}\n')
             f.write(f'summary: {summary}\n')
             f.write(f'issuetype: {issuetype}\n')

--- a/mantis/drafts/template.md
+++ b/mantis/drafts/template.md
@@ -1,0 +1,12 @@
+---
+ignore: True
+project: {project}
+parent: {parent}
+summary: {summary}
+issuetype: {issuetype}
+assignee: {assignee}
+---
+# {summary}
+
+{description}
+

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 from pathlib import Path
+import os
 import json
 import requests
 
@@ -26,11 +27,16 @@ class JiraClient:
         self.cache_dir = Path(self.options.cache_dir)
         self.cache_dir.mkdir(exist_ok=True)
         (self.cache_dir / 'issues').mkdir(exist_ok=True)
+        self.drafts_dir = Path(self.options.drafts_dir)
+        self.drafts_dir.mkdir(exist_ok=True)
         self.issues = JiraIssues(self)
 
     def write_to_cache(self, file_name: str, contents: str):
         with open(self.cache_dir / file_name, 'w') as f:
             return f.write(contents)
+
+    def remove_from_cache(self, file_name: str):
+        os.remove(self.cache_dir / file_name)
 
     def get_from_cache(self, file_name: str):
         if not (self.cache_dir / file_name).exists():
@@ -73,6 +79,9 @@ class JiraClient:
         issue_data = self.get_from_cache(f'issues/{key}.json')
         if issue_data:
             return json.loads(issue_data)
+
+    def remove_issue_from_cache(self, key: str):
+        self.remove_from_cache(f'issues/{key}.json')
 
     @property
     def api_url(self):

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -32,8 +32,6 @@ class JiraClient:
         self.issues = JiraIssues(self)
 
     def write_to_cache(self, file_name: str, contents: str):
-        if self._no_cache:
-            raise PermissionError('Cache dir not activated')
         with open(self.cache_dir / file_name, 'w') as f:
             return f.write(contents)
 
@@ -41,8 +39,6 @@ class JiraClient:
         os.remove(self.cache_dir / file_name)
 
     def get_from_cache(self, file_name: str):
-        if self._no_cache:
-            raise PermissionError('Cache dir not activated')
         if not (self.cache_dir / file_name).exists():
             return
         with open(self.cache_dir / file_name, 'r') as f:

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -32,6 +32,8 @@ class JiraClient:
         self.issues = JiraIssues(self)
 
     def write_to_cache(self, file_name: str, contents: str):
+        if self._no_cache:
+            raise PermissionError('Cache dir not activated')
         with open(self.cache_dir / file_name, 'w') as f:
             return f.write(contents)
 
@@ -39,6 +41,8 @@ class JiraClient:
         os.remove(self.cache_dir / file_name)
 
     def get_from_cache(self, file_name: str):
+        if self._no_cache:
+            raise PermissionError('Cache dir not activated')
         if not (self.cache_dir / file_name).exists():
             return
         with open(self.cache_dir / file_name, 'r') as f:

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -29,9 +29,10 @@ class JiraIssues:
             self.allowed_types = {_.get('name') for _ in cached_issuetypes}
 
     def get(self, key: str) -> dict:
-        issue_from_cache = self.client.get_issue_from_cache(key)
-        if issue_from_cache:
-            return issue_from_cache
+        if not self.client._no_cache:
+            issue_from_cache = self.client.get_issue_from_cache(key)
+            if issue_from_cache:
+                return issue_from_cache
         response = self.client.get_issue(key)
         try:
             response.raise_for_status()

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -38,7 +38,8 @@ class JiraIssues:
         except HTTPError as e:
             self.handle_http_error(e, key)
         data = response.json()
-        self.client.write_issue_to_cache(key, data)
+        if not self.client._no_cache:
+            self.client.write_issue_to_cache(key, data)
         return data
 
     def create(self, issue_type, title, data):

--- a/mantis/jira/jira_options.py
+++ b/mantis/jira/jira_options.py
@@ -25,6 +25,7 @@ class JiraOptions:
         self.project = parser and parser.project or options.get('jira', {}).get('project')
         self.no_verify_ssl = bool(parser and parser.no_verify_ssl or options.get('jira', {}).get('no-verify-ssl'))
         self.cache_dir = parser and parser.cache_dir or options.get('jira', {}).get('cache-dir')
+        self.drafts_dir = parser and parser.drafts_dir or options.get('jira', {}).get('drafts-dir')
         self.action = parser and parser.action or ''
         self.issues: list[str] = parser and parser.issues or []
         assert self.user, 'JiraOptions.user not set'
@@ -32,6 +33,7 @@ class JiraOptions:
         assert self.url, 'JiraOptions.url not set'
         assert self.project, 'JiraOptions.project not set'
         assert self.cache_dir, 'JiraOptions.cache_dir not set'
+        assert self.drafts_dir, 'JiraOptions.drafts_dir not set'
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -46,6 +48,7 @@ def parse_args():
     parser.add_argument('--no-verify-ssl', dest='no_verify_ssl', default=False,
                         action='store_true', help='Do not verify SSL certificates for requests')
     parser.add_argument('--cache-dir', dest='cache_dir', default=None, help='Set the local cache for Jira data')
+    parser.add_argument('--drafts-dir', dest='drafts_dir', default=None, help='Set the local drafts directory for Jira issues')
     parser.add_argument('--action', dest='action', default='get-issue', help='Get an issue from Jira')
     parser.add_argument('issues', nargs='*', help='List of issues by key (e.g. TASK-1, TASK-2, TASK-3, etc.)')
     return parser.parse_args()

--- a/options-example.toml
+++ b/options-example.toml
@@ -4,4 +4,5 @@ url = "https://account.atlassian.net"
 project = "TEST"
 personal-access-token = "zxcv_JIRA_TOKEN"
 cache-dir = ".jira_cache"
+drafts-dir = "drafts"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,3 +70,8 @@ def jira_client_from_fake_cli(opts_from_fake_cli):
 def jira_issues_from_fake_cli(jira_client_from_fake_cli):
     return JiraIssues(jira_client_from_fake_cli)
 
+@pytest.fixture
+def jira_client_from_fake_cli_no_cache(opts_from_fake_cli):
+    auth = JiraAuth(opts_from_fake_cli)
+    return JiraClient(opts_from_fake_cli, auth, no_cache=True)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ class Cli:
     project = 'TEST'
     no_verify_ssl = False
     cache_dir = ".jira_cache_test"
+    drafts_dir = "drafts_test"
     action = ''
     issues = ['']
 
@@ -36,6 +37,7 @@ def fake_toml(tmpdir):
         'personal-access-token = "SECRET_2"',
         'project = "TEST"',
         'cache-dir = ".jira_cache_test"',
+        'drafts-dir = "drafts_test"'
         ''
     ))
     toml = tmpdir / "options.toml"

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -1,0 +1,65 @@
+from mantis.drafts import Draft
+import pytest
+import os
+import re
+from mantis.jira import JiraClient, JiraAuth
+import requests
+from unittest.mock import patch
+
+@pytest.fixture
+def fake_jira_issues():
+    pass
+
+@pytest.fixture
+def fake_jira(opts_from_fake_cli, mock_get_request):
+    expected = {'key': 'TASK-1',
+                'fields': {
+                    'status': {'name': 'resolved'},
+                    'summary': 'Test issue',
+                    'parent': 'TASK-0',
+                    # 'project': {'key': 'ABC-123'},
+                    'issuetype': {'key': 'Task'},
+                    'assignee': {'displayName': 'Bobby Goodsky'},
+                }}
+    mock_get_request.return_value.json.return_value = expected
+    auth = JiraAuth(opts_from_fake_cli)
+    return JiraClient(opts_from_fake_cli, auth)
+
+from pathlib import Path
+def test_JiraDraft(tmp_path, fake_jira: JiraClient):
+    drafts_dir = tmp_path / 'drafts'
+    drafts_dir.mkdir()
+    fake_jira._no_cache = True
+    task_1 = fake_jira.issues.get('TASK-44')
+    assert type(task_1) == dict
+    # assert task_1.get('fields', {}).get('project', {}) == {'key': 'ABC-123'}
+    # assert task_1.get('fields', {}).get('project', {}).get('key') == 'ABC-123'
+    assert len(list(drafts_dir.iterdir())) == 0
+    draft = Draft(task_1, drafts_dir)
+    assert len([*drafts_dir.iterdir()]) == 1
+    # draft._materialize()
+    # assert len(list(drafts_dir.iterdir())) == 1
+
+    with open(drafts_dir / 'TASK-1.md', 'r') as f:
+        content = f.read()
+    # assert content == '1'
+    assert 'assignee: Bobby Goodsky' in content
+
+    expectations = (
+                '---',
+                'header: [TASK-1] Test issue',
+                'ignore: True',
+                'parent: TASK-0',
+                'summary: Test issue',
+                'issuetype: None',
+                'assignee: Bobby Goodsky',
+                '---',
+                '# Test issue',
+                '',
+                'None',
+    )
+    with open(drafts_dir / 'TASK-1.md', 'r') as f:
+        for content, expected in zip(f.readlines(), expectations):
+            assert content.strip() == expected
+
+

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -3,7 +3,7 @@ import os
 import re
 from mantis.jira import JiraClient, JiraAuth
 import requests
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 @pytest.fixture
 def fake_jira(opts_from_fake_cli, mock_get_request):
@@ -21,6 +21,19 @@ def fake_jira(opts_from_fake_cli, mock_get_request):
 
 def test_JiraIssuesGetFake(fake_jira):
     task_1 = fake_jira.issues.get('TASK-1')
+    assert task_1.get('key') == 'TASK-1'
+    assert task_1.get('fields', {}).get('status') == {'name': 'resolved'}
+
+def test_JiraIssuesGetFake2(jira_client_from_fake_cli_no_cache):
+    expected = {'key': 'TASK-1', 'fields': {'status': {'name': 'resolved'}}}
+    mock_response = MagicMock(spec=requests.models.Response)
+    mock_response.status_code = 200
+    mock_response.ok = True
+    mock_response.json = lambda: expected
+    mock_response.headers = {"Content-Type": "text/plain"}
+    mock_response.text = 'ULTI_JOKE'
+    with patch("requests.get", return_value=mock_response):
+        task_1 = jira_client_from_fake_cli_no_cache.issues.get('TASK-1')
     assert task_1.get('key') == 'TASK-1'
     assert task_1.get('fields', {}).get('status') == {'name': 'resolved'}
 

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -39,10 +39,11 @@ def test_JiraIssuesGetFake2(jira_client_from_fake_cli_no_cache):
 
 def test_JiraIssuesGetNonExistent(jira_client_from_fake_cli):
     jira_client_from_fake_cli._no_cache = True
-    _mock_response = requests.models.Response()
-    _mock_response.status_code = 404
-    _mock_response.reason = "Not Found"
-    with patch("requests.get", return_value=_mock_response):
+    mock_response = requests.models.Response()
+    # mock_response.ok = False
+    mock_response.status_code = 404
+    mock_response.reason = "Not Found"
+    with patch("requests.get", return_value=mock_response):
         with pytest.raises(ValueError,
                            match=('The issue "TEST-999" does not exists in '
                            'the project "TEST"')):

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -17,7 +17,7 @@ def test_JiraIssuesGetFake(fake_jira):
     assert task_1.get('key') == 'TASK-1'
     assert task_1.get('fields', {}).get('status') == {'name': 'resolved'}
 
-def test_JiraIssuesGetFake2(jira_client_from_fake_cli_no_cache):
+def test_JiraIssuesGetMocked(jira_client_from_fake_cli_no_cache):
     expected = {'key': 'TASK-1', 'fields': {'status': {'name': 'resolved'}}}
     mock_response = Mock()
     mock_response.status_code = 200

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -8,6 +8,13 @@ from unittest.mock import patch
 @pytest.fixture
 def fake_jira(opts_from_fake_cli, mock_get_request):
     expected = {'key': 'TASK-1', 'fields': {'status': {'name': 'resolved'}}}
+    # expected = {'key': 'TASK-1',
+    #         'fields': {
+    #             'status': {'name': 'resolved'},
+    #             'project': {'key': 'ABC-123'},
+    #             'issuetype': {'key': 'Task'},
+    #             'assignee': {'displayName': 'Bobby Goodsky'},
+    #         }}
     mock_get_request.return_value.json.return_value = expected
     auth = JiraAuth(opts_from_fake_cli)
     return JiraClient(opts_from_fake_cli, auth)
@@ -15,7 +22,7 @@ def fake_jira(opts_from_fake_cli, mock_get_request):
 def test_JiraIssuesGetFake(fake_jira):
     task_1 = fake_jira.issues.get('TASK-1')
     assert task_1.get('key') == 'TASK-1'
-    assert task_1.get('fields') == {'status': {'name': 'resolved'}}
+    assert task_1.get('fields', {}).get('status') == {'name': 'resolved'}
 
 def test_JiraIssuesGetNonExistent(jira_client_from_fake_cli):
     jira_client_from_fake_cli._no_cache = True


### PR DESCRIPTION
In order to store markdown files for local editing, create a `drafts` directory.

Created a `JiraClient._no_cache` attribute to control the use of the cache.

Also implemented bare-bones functionality for writing markdown files from the JIra API.

```sh
$ python main.py TASK-1
[TASK-1] Test issue
$ bat drafts/TASK-1.md
───────┬──────────────────────────────────
       │ File: drafts/TASK-1.md
───────┼──────────────────────────────────
   1   │ ---
   2   │ header: [TASK-1] Test issue
   3   │ ignore: True
   4   │ parent: TASK-0
   5   │ summary: Test issue
   6   │ issuetype: None
   7   │ assignee: Bobby Goodsky
   8   │ ---
   9   │ # Test issue
  10   │
  11   │ None
  12   │
───────┴──────────────────────────────────
```