### PR TITLE
Inspect project field keys

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,8 @@ if __name__ == '__main__':
         resp = jira.system_config_loader.update_project_field_keys()
         print('Dumped field values for:')
         pprint(resp)
+    elif jira_options.action == 'get-project-keys-from-cache':
+        jira.system_config_loader.inspect()
     else:
         print(f'Action {jira_options.action} not recognized')
 

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
         resp = jira.system_config_loader.update_project_field_keys()
         print('Dumped field values for:')
         pprint(resp)
-    elif jira_options.action == 'get-project-keys-from-cache':
+    elif jira_options.action == 'inspect':
         jira.system_config_loader.inspect()
     else:
         print(f'Action {jira_options.action} not recognized')

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -47,6 +47,10 @@ class JiraClient:
         with open(self.cache_dir / file_name, 'r') as f:
             return f.read()
 
+    def get_from_cache_decoded(self, file_name: str) -> dict:
+        with open(self.cache_dir / file_name, 'r') as f:
+            return json.load(f)
+
     def write_issue_to_cache(self, key: str, data):
         self.write_to_cache(f'issues/{key}.json', json.dumps(data))
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -56,6 +56,8 @@ def fetch_enums(jira: 'JiraClient',
 class ProjectFieldKeys:
     def __init__(self, name: str, data: Mapping[str, list[Project]]) -> None:
         assert data
+        # print (data['projects'][0].keys())
+        # dict_keys(['expand', 'self', 'id', 'key', 'name', 'avatarUrls', 'issuetypes'])
         self.name = name
         self.data = data
 
@@ -77,6 +79,8 @@ class ProjectFieldKeys:
     def show(self) -> None:
         pprint(', '.join(self.fields))
         return self.fields
+        # for field in self.fields:
+        #     print (field)
 
 class JiraSystemConfigLoader:
     def __init__(self, client: 'JiraClient') -> None:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -92,6 +92,9 @@ class JiraSystemConfigLoader:
     def get_from_system_cache(self, file_name: str) -> str | None:
         return self.client.get_from_cache(f'system/{file_name}')
 
+    def get_from_system_cache_decoded(self, file_name: str) -> dict:
+        return self.client.get_from_cache_decoded(f'system/{file_name}')
+
     def update_issuetypes_cache(self) -> None:
         types_filter = lambda d: int(d['id']) < 100 and d['name'] in (
             'Bug', 'Task', 'Epic', 'Story', 'Sub-Task',

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -56,8 +56,6 @@ def fetch_enums(jira: 'JiraClient',
 class ProjectFieldKeys:
     def __init__(self, name: str, data: Mapping[str, list[Project]]) -> None:
         assert data
-        # print (data['projects'][0].keys())
-        # dict_keys(['expand', 'self', 'id', 'key', 'name', 'avatarUrls', 'issuetypes'])
         self.name = name
         self.data = data
 
@@ -79,8 +77,6 @@ class ProjectFieldKeys:
     def show(self) -> None:
         pprint(', '.join(self.fields))
         return self.fields
-        # for field in self.fields:
-        #     print (field)
 
 class JiraSystemConfigLoader:
     def __init__(self, client: 'JiraClient') -> None:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -127,6 +127,7 @@ class JiraSystemConfigLoader:
             response = self.client._get(url)
             response.raise_for_status()
             data = response.json()
-            self.write_to_system_cache(f'issue_type_fields/{issue_type}.json', json.dumps(data))
+            self.write_to_system_cache(
+                f'issue_type_fields/{issue_type}.json', json.dumps(data))
         return self.client.issues.allowed_types
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -1,6 +1,8 @@
 import json
+from pprint import pprint
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
+from mantis.jira.utils.jira_types import Project
 
 if TYPE_CHECKING:
     from jira_client import JiraClient
@@ -50,6 +52,31 @@ def fetch_enums(jira: 'JiraClient',
         if not filter or filter(schema):
             schemas.append(schema)
     return schemas
+
+class ProjectFieldKeys:
+    def __init__(self, name: str, data: Mapping[str, list[Project]]) -> None:
+        assert data
+        self.name = name
+        self.data = data
+
+    @property
+    def fields(self) -> list[str]:
+        projects = self.data.get('projects')
+        assert projects, 'Data does not contain "projects" field'
+        assert len(projects) == 1, 'Expected exactly one project'
+        project = projects[0]
+        issue_types = project.get('issuetypes')
+        assert issue_types, 'Projects does not contain "issuetypes" field'
+        assert len(issue_types) == 1, 'Expected exactly one issue_type'
+        issue_type = issue_types[0]
+        fields = issue_type.get('fields')
+        assert fields, 'Issue_types does not contain "fields" field'
+        assert len(fields) > 0
+        return list(fields.keys())
+
+    def show(self) -> None:
+        pprint(', '.join(self.fields))
+        return self.fields
 
 class JiraSystemConfigLoader:
     def __init__(self, client: 'JiraClient') -> None:


### PR DESCRIPTION
Jira allow users to create custom fields. The metadata about these fields need to be fetched from the Jira web service. The fields are stored in a nested structure, that we will need to parse later. For now, we just want to parse the rest of the structure, in order to get to the field data at all.
- Create `ProjectFieldKeys` for traversing the Jira metadata payload for project
- In `JiraSystemConfigLoader`, create an `inspect` method and a few supporting methods to output a report on which issue types use which fields.

Example (notice that `Epic` has an extra field (`customfield_10001`) that the other types do not.)
```
$ python main.py --action 'inspect'
                     - Bug       Sub-Task  Task      Epic      Story     
issuelinks           - 1         1         1         1         1         
summary              - 1         1         1         1         1         
assignee             - 1         1         1         1         1         
issuetype            - 1         1         1         1         1         
customfield_10001    -                               1                   
project              - 1         1         1         1         1         
parent               - 1         1         1         1         1         
description          - 1         1         1         1         1         
labels               - 1         1         1         1         1         
                     - Bug       Sub-Task  Task      Epic      Story     
```