### PR TITLE
Generate models from upstream

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,8 @@ if __name__ == '__main__':
         pprint(resp)
     elif jira_options.action == 'inspect':
         jira.system_config_loader.inspect()
+    elif jira_options.action == 'compile-plugins':
+        jira.system_config_loader.compile_plugins()
     else:
         print(f'Action {jira_options.action} not recognized')
 

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -31,6 +31,8 @@ class JiraClient:
         (self.cache_dir / 'system' / 'issue_type_fields').mkdir(exist_ok=True)
         self.drafts_dir = Path(self.options.drafts_dir)
         self.drafts_dir.mkdir(exist_ok=True)
+        self.plugins_dir = Path('plugins')
+        self.plugins_dir.mkdir(exist_ok=True)
         self.system_config_loader = JiraSystemConfigLoader(self)
         self.issues = JiraIssues(self)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests.auth
 pytest-xdist
 pytest-cov
 pydantic
+datamodel-code-generator


### PR DESCRIPTION
Taking the Jira `project metadata` files as input, we want to dynamically build the models for interacting with a Jira account.
- Introduce `JiraSystemConfigLoader.compile_plugins` to generate classes from upstream
- Create a `plugins` directory for writing models for later consumption

Utilizing [datamodel-code-generator](https://github.com/koxudaxi/datamodel-code-generator) to automatically translate json files to Pydantic-compatible Python classes.
