### PR TITLE
Load generated models

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,21 @@ An example of the coverage report:
 
 ![Markdown coverage report](docs/img/pytest-coverage-html-report.png)
 
+# Generate types
+
+```python
+from plugins import model
+for x in dir(model): print (x)
+... 
+Assignee
+Attachment
+AvatarUrls
+BaseModel
+Components
+Configuration
+Customfield10001
+Customfield10002
+Customfield10003
+[...]
+```
+

--- a/main.py
+++ b/main.py
@@ -35,6 +35,16 @@ if __name__ == '__main__':
         jira.system_config_loader.inspect()
     elif jira_options.action == 'compile-plugins':
         jira.system_config_loader.compile_plugins()
+    elif jira_options.action == 'load-plugins':
+        from plugins import Plugins
+        print(Plugins.all_plugins['plugins_test'].Schema(type='a', system='b'))
+        print(Plugins.plugins_test.Schema(type='a', system='b'))
+
+        import plugins
+        print(plugins.plugins_test.Schema(type='a', system='b'))
+
+        from plugins.plugins_test import Schema
+        print(Schema(type='a', system='b'))
     else:
         print(f'Action {jira_options.action} not recognized')
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,11 @@
+import os
+import importlib
+
+module_dir = os.path.dirname(__file__)
+
+for filename in os.listdir(module_dir):
+    if filename.endswith('.py') and filename != '__init__.py':
+        # Remove the .py extension
+        module_name = filename[:-3]
+        importlib.import_module(f'.{module_name}', package=__name__)
+

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -9,3 +9,33 @@ for filename in os.listdir(module_dir):
         module_name = filename[:-3]
         importlib.import_module(f'.{module_name}', package=__name__)
 
+class Plugins:
+    """
+    Plugins class for import at runtime.
+    
+    from plugins import Plugins
+    Plugins.my_model
+    Plugins.my_other_model
+    
+    Or iterate through all registered plugins:
+    for plugin Plugins.all_plugins:
+        print(plugin)
+    """
+    all_plugins: dict[str, any] = {}
+    
+    @classmethod
+    def stats(cls):
+        print('The following plugins have been loaded:')
+        for plugin_name, plugin in cls.all_plugins.items():
+            models_in_plugin = [_ for _ in dir(plugin) if not _.startswith('_')]
+            model_count = len(models_in_plugin)
+            print(f'- {plugin_name} ({model_count})')
+
+for filename in os.listdir(module_dir):
+    if filename.endswith('.py') and filename != '__init__.py':
+        # Remove the .py extension
+        module_name = filename[:-3]
+        # Set each plugin as an attribute of the Plugins class
+        imported_plugin = importlib.import_module(f'.{module_name}', package=__name__)
+        setattr(Plugins, module_name, imported_plugin)
+        Plugins.all_plugins[module_name] = imported_plugin

--- a/plugins/plugins_test.py
+++ b/plugins/plugins_test.py
@@ -1,0 +1,9 @@
+# Example to illustrate code-gen
+#   filename:  .jira_cache/system/issue_type_fields/Test.json
+#   timestamp: 2025-04-20T20:03:40+00:00
+
+from pydantic import BaseModel
+
+class Schema(BaseModel):
+    type: str
+    system: str


### PR DESCRIPTION
We want to model the Jira data model locally, in order to mirror the functionality of the website. With the newly created `plugins` directory, users can now generate models and instantiate objects that are based on the upstream data.
- Create a `module loader` (see `plugins/__init__.py`), allowing users to dynamically load generated models: `import plugins`
- Create class inside the `plugins` module, because I'm unsure if I want to to one or the other: `from plugins import Plugins`
- Create example plugin: `plugins/plugins_test.py`

We want to be able to automatically load all modules, and we want them to be namespaced. 

Either of these solutions work, I just haven't decided which way to go yet.

```python
$ from plugins import Plugins
$ Plugins.all_plugins['plugins_test'].Schema(type='a', system='b')
type='a' system='b'

$ print(Plugins.plugins_test.Schema(type='a', system='b'))
type='a' system='b'

$ import plugins
$ plugins.plugins_test.Schema(type='a', system='b')
type='a' system='b'

$ from plugins.plugins_test import Schema
$ Schema(type='a', system='b')
type='a' system='b'
```
