### PR TITLE
Apply test naming conventions

### DIFF
--- a/tests/test_jira_auth.py
+++ b/tests/test_jira_auth.py
@@ -10,12 +10,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from mantis.jira.jira_options import JiraOptions
 
-def test_CreatesJiraAuthSettings(fake_toml):
+def test_creates_jira_auth_settings(fake_toml):
     opts = JiraOptions(toml_source = fake_toml)
     auth = JiraAuth(opts)
     assert isinstance(auth.auth, HTTPBasicAuth)
 
-def test_FailedJiraAuthSettingsRaises(fake_cli):
+def test_failed_jira_auth_settings_raises(fake_cli):
     fake_cli.personal_access_token = None
     with pytest.raises(PermissionError):
         JiraAuth(fake_cli).auth

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -10,6 +10,6 @@ def fake_jira_client_for_test_auth(opts_from_fake_cli, mock_get_request):
     return JiraClient(opts_from_fake_cli, auth)
 
 @pytest.mark.skipif(not os.path.exists("options.toml"), reason='File "options.toml" does not exist')
-def test_JiraOptionsOverride(fake_jira_client_for_test_auth):
+def test_jira_options_override(fake_jira_client_for_test_auth):
     fake_jira_client_for_test_auth.test_auth()
 

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -18,7 +18,7 @@ def fake_jira(opts_from_fake_cli, mock_get_request):
     auth = JiraAuth(opts_from_fake_cli)
     return JiraClient(opts_from_fake_cli, auth)
 
-def test_JiraDraft(tmp_path, fake_jira: JiraClient):
+def test_jira_draft(tmp_path, fake_jira: JiraClient):
     drafts_dir = tmp_path / 'drafts'
     drafts_dir.mkdir()
     fake_jira._no_cache = True

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -12,12 +12,12 @@ def fake_jira(opts_from_fake_cli, mock_get_request):
     auth = JiraAuth(opts_from_fake_cli)
     return JiraClient(opts_from_fake_cli, auth)
 
-def test_JiraIssuesGetFake(fake_jira):
+def test_jira_issues_get_fake(fake_jira):
     task_1 = fake_jira.issues.get('TASK-1')
     assert task_1.get('key') == 'TASK-1'
     assert task_1.get('fields', {}).get('status') == {'name': 'resolved'}
 
-def test_JiraIssuesGetMocked(jira_client_from_fake_cli_no_cache: JiraClient):
+def test_jira_issues_get_mocked(jira_client_from_fake_cli_no_cache: JiraClient):
     expected = {'key': 'TASK-1', 'fields': {'status': {'name': 'resolved'}}}
     mock_response = Mock()
     mock_response.status_code = 200
@@ -30,7 +30,7 @@ def test_JiraIssuesGetMocked(jira_client_from_fake_cli_no_cache: JiraClient):
     assert task_1.get('key') == 'TASK-1'
     assert task_1.get('fields', {}).get('status') == {'name': 'resolved'}
 
-def test_JiraIssuesGetNonExistent(jira_client_from_fake_cli_no_cache):
+def test_jira_issues_get_non_existent(jira_client_from_fake_cli_no_cache):
     mock_response = Mock()
     mock_response.reason = "Not Found"
     mock_response.raise_for_status.side_effect = HTTPError()
@@ -60,7 +60,7 @@ def test_JiraIssuesGetNonExistent(jira_client_from_fake_cli_no_cache):
 
 @pytest.mark.skipif(not os.path.exists("options.toml"), reason='File "options.toml" does not exist')
 @pytest.mark.skipif(not os.getenv('EXECUTE_SKIPPED'), reason="This is a live test against the Jira api")
-def test_JiraIssuesGetReal(jira_client_from_user_toml):
+def test_jira_issues_get_real(jira_client_from_user_toml):
     test_3 = jira_client_from_user_toml.issues.get('TEST-3')
     assert test_3.get('key') == 'TEST-3'
     test_3_fields = test_3.get('fields', {})
@@ -70,7 +70,7 @@ def test_JiraIssuesGetReal(jira_client_from_user_toml):
     test_3_status_name = test_3_status.get('name', {})
     assert test_3_status_name == 'In Progress'
 
-def test_JiraIssuesCreate(jira_issues_from_fake_cli, mock_post_request):
+def test_jira_issues_create(jira_issues_from_fake_cli, mock_post_request):
     with pytest.raises(ValueError):
         issue = jira_issues_from_fake_cli.create(issue_type='Bug', title='Tester', data={})
     expected = {'key': 'TASK-1', 'fields': {'status': {'name': 'In Progress'}, 'issuetype': {'name': 'Bug'}}}

--- a/tests/test_jira_options.py
+++ b/tests/test_jira_options.py
@@ -3,19 +3,19 @@ import os
 
 from mantis.jira import JiraOptions
 
-def test_JiraOptions(fake_toml):
+def test_jira_options(fake_toml):
     opts = JiraOptions(toml_source = fake_toml)
     assert opts.user == 'user_2@domain.com'
     assert opts.url == 'https://account_2.atlassian-host.net'
     assert opts.personal_access_token == 'SECRET_2'
 
-def test_JiraOptionsOverride(fake_toml, fake_cli):
+def test_jira_options_override(fake_toml, fake_cli):
     opts = JiraOptions(toml_source = fake_toml, parser = fake_cli)
     assert opts.user == 'user_1@domain.com'
     assert opts.url == 'https://account_1.atlassian-host.net'
     assert opts.personal_access_token == 'SECRET_1'
 
-def test_JiraOptionsNotSet(tmpdir, capfd):
+def test_jira_options_not_set(tmpdir, capfd):
     toml = tmpdir / "options.toml"
     with pytest.raises(AssertionError):
         opts = JiraOptions(toml_source = toml)
@@ -28,7 +28,7 @@ def test_JiraOptionsNotSet(tmpdir, capfd):
     assert out == 'No toml_source provided and default "options.toml" does not exist\n'
 
 @pytest.mark.skipif(not os.path.exists("options.toml"), reason='File "options.toml" does not exist')
-def test_OptsFromUserTomlValues(opts_from_user_toml):
+def test_opts_from_user_toml_values(opts_from_user_toml):
     assert opts_from_user_toml.user != 'user_1@domain.com'
     assert opts_from_user_toml.url != 'https://account_1.atlassian-host.net'
     assert opts_from_user_toml.personal_access_token != 'SECRET_1'


### PR DESCRIPTION
Don't use camel case for test names.