### PR TITLE
Test coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_also =
+    if TYPE_CHECKING:
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 
 [[requests.auth]]
 follow_untyped_imports = "True"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+


### PR DESCRIPTION
Configure coverage reports to ignore `if TYPE_CHECKING:` blocks.

Also explicitly set `tests` as the default `test` directory for pytest.
