### PR TITLE
Expand options

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -32,7 +32,7 @@ class JiraClient:
         self.cache = Cache(self)
         self.drafts_dir = Path(self.options.drafts_dir)
         self.drafts_dir.mkdir(exist_ok=True)
-        self.plugins_dir = Path("plugins")
+        self.plugins_dir = Path(self.options.plugins_dir)
         self.plugins_dir.mkdir(exist_ok=True)
         self.system_config_loader = JiraSystemConfigLoader(self)
         self.issues = JiraIssues(self)

--- a/mantis/jira/jira_options.py
+++ b/mantis/jira/jira_options.py
@@ -49,6 +49,11 @@ class JiraOptions:
         self.plugins_dir = (
             parser and parser.plugins_dir or options.get("jira", {}).get("plugins-dir")
         )
+        self.type_id_cutoff = int(
+            parser
+            and parser.type_id_cutoff
+            or options.get("jira", {}).get("type-id-cutoff", 10100)
+        )
         self.action = parser and parser.action or ""
         self.issues: list[str] = parser and parser.issues or []
         assert self.user, "JiraOptions.user not set"
@@ -107,6 +112,12 @@ def parse_args():
         dest="plugins_dir",
         default=None,
         help="Set the local plugins directory for models",
+    )
+    parser.add_argument(
+        "--type-id-cutoff",
+        dest="type_id_cutoff",
+        default=None,
+        help="Set the cutoff for Jira types to fetch",
     )
     parser.add_argument(
         "--action", dest="action", default="get-issue", help="Get an issue from Jira"

--- a/mantis/jira/jira_options.py
+++ b/mantis/jira/jira_options.py
@@ -46,6 +46,9 @@ class JiraOptions:
         self.drafts_dir = (
             parser and parser.drafts_dir or options.get("jira", {}).get("drafts-dir")
         )
+        self.plugins_dir = (
+            parser and parser.plugins_dir or options.get("jira", {}).get("plugins-dir")
+        )
         self.action = parser and parser.action or ""
         self.issues: list[str] = parser and parser.issues or []
         assert self.user, "JiraOptions.user not set"
@@ -98,6 +101,12 @@ def parse_args():
         dest="drafts_dir",
         default=None,
         help="Set the local drafts directory for Jira issues",
+    )
+    parser.add_argument(
+        "--plugins-dir",
+        dest="plugins_dir",
+        default=None,
+        help="Set the local plugins directory for models",
     )
     parser.add_argument(
         "--action", dest="action", default="get-issue", help="Get an issue from Jira"

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -76,7 +76,9 @@ class JiraSystemConfigLoader:
             yield file
 
     def update_issuetypes_cache(self) -> None:
-        types_filter = lambda d: int(d["id"]) < 100 and d["name"] in (
+        types_filter = lambda d: int(d["id"]) <= self.client.options.type_id_cutoff and d[
+            "name"
+        ] in (
             "Bug",
             "Task",
             "Epic",

--- a/options-example.toml
+++ b/options-example.toml
@@ -5,4 +5,5 @@ project = "TEST"
 personal-access-token = "zxcv_JIRA_TOKEN"
 cache-dir = ".jira_cache"
 drafts-dir = "drafts"
+plugins-dir = "plugins"
 

--- a/options-example.toml
+++ b/options-example.toml
@@ -6,4 +6,5 @@ personal-access-token = "zxcv_JIRA_TOKEN"
 cache-dir = ".jira_cache"
 drafts-dir = "drafts"
 plugins-dir = "plugins"
+type_id_cutoff = "10100"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ class Cli:
     cache_dir = ".jira_cache_test"
     drafts_dir = "drafts_test"
     plugins_dir = "plugins_test"
+    type_id_cutoff = "10100"
     action = ""
     issues = [""]
 
@@ -45,7 +46,8 @@ def fake_toml(tmpdir):
             'project = "TEST"',
             'cache-dir = ".jira_cache_test"',
             'drafts-dir = "drafts_test"',
-            'plugins-dir = "plugins_test"' "",
+            'plugins-dir = "plugins_test"',
+            'type-id-cutoff = "10100"' "",
         )
     )
     toml = tmpdir / "options.toml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ class Cli:
     no_verify_ssl = False
     cache_dir = ".jira_cache_test"
     drafts_dir = "drafts_test"
+    plugins_dir = "plugins_test"
     action = ""
     issues = [""]
 
@@ -43,7 +44,8 @@ def fake_toml(tmpdir):
             'personal-access-token = "SECRET_2"',
             'project = "TEST"',
             'cache-dir = ".jira_cache_test"',
-            'drafts-dir = "drafts_test"' "",
+            'drafts-dir = "drafts_test"',
+            'plugins-dir = "plugins_test"' "",
         )
     )
     toml = tmpdir / "options.toml"


### PR DESCRIPTION
Add missing option for `plugins_dir`.

Also add option `type-id-cutoff` for controlling previously hard-coded filter when updating the issue type cache.