### PR TITLE
Modular pytest fixtures

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
             key = issue.get('key', 'N/A')
             title = issue.get_field('summary')
             print(f'[{key}] {title}')
-            draft = Draft(issue)
+            draft = Draft(jira, issue)
     elif jira_options.action == 'get-project-keys':
         print ('Fetching from Jira...')
         resp = jira.system_config_loader.update_project_field_keys()

--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 # To-do: Create converter for Jira syntax to markdown.
@@ -6,14 +5,13 @@ j2m = lambda x: x
 
 if TYPE_CHECKING:
     from mantis.jira import JiraIssue
+    from mantis.jira.jira_client import JiraClient
 
 
 class Draft:
-    def __init__(self, issue: "JiraIssue", drafts_dir: Path | None = None) -> None:
-        if not drafts_dir:
-            drafts_dir = Path("drafts")
-        self.dir = drafts_dir
-        self.dir.mkdir(exist_ok=True)
+    def __init__(self, jira: "JiraClient", issue: "JiraIssue") -> None:
+        assert jira.drafts_dir
+        self.jira = jira
         self.issue = issue
         self._materialize()
 
@@ -32,7 +30,7 @@ class Draft:
         assignee = assignee.get("displayName")
         description = self.issue.get_field("description")
 
-        with open(self.dir / (key + ".md"), "w") as f:
+        with open(self.jira.drafts_dir / f"{key}.md", "w") as f:
             f.write(f"---\n")
             f.write(f"header: [{key}] {summary}\n")
             f.write(f"ignore: True\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import requests
 
 from mantis.jira import JiraAuth, JiraClient, JiraIssues, JiraOptions
 from mantis.jira.utils.cache import Cache
@@ -83,19 +83,24 @@ def jira_client_from_fake_cli(opts_from_fake_cli):
 
 
 @pytest.fixture
-def jira_issues_from_fake_cli(jira_client_from_fake_cli):
-    return JiraIssues(jira_client_from_fake_cli)
+def with_no_cache(fake_jira):
+    fake_jira._no_cache = True
 
 
 @pytest.fixture
-def jira_client_from_fake_cli_no_cache(opts_from_fake_cli):
-    auth = JiraAuth(opts_from_fake_cli)
-    return JiraClient(opts_from_fake_cli, auth, no_cache=True)
+def with_fake_cache(opts_from_fake_cli, tmp_path: Path):
+    (tmp_path / "cache").mkdir(exist_ok=True)
+    opts_from_fake_cli.cache_dir = tmp_path / "cache"
 
 
 @pytest.fixture
-def jira_client_from_fake_cli_with_fake_cache(tmp_path, jira_client_from_fake_cli):
+def with_fake_drafts_dir(fake_jira, tmp_path: Path):
+    (tmp_path / "drafts").mkdir(exist_ok=True)
+    fake_jira.drafts_dir = tmp_path / "drafts"
+
+
+@pytest.fixture
+def fake_jira(with_fake_cache, jira_client_from_fake_cli):
     jira = jira_client_from_fake_cli
-    jira.options.cache_dir = tmp_path
-    jira.cache = Cache(jira)
+    assert str(jira.cache.root) != ".jira_cache_test"
     return jira

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-import requests
 
 from mantis.jira import JiraAuth, JiraClient
 
@@ -20,12 +19,11 @@ def test_jira_options_override(fake_jira_client_for_test_auth):
     fake_jira_client_for_test_auth.test_auth()
 
 
-def test_cache_exists(jira_client_from_fake_cli_with_fake_cache):
-    jira = jira_client_from_fake_cli_with_fake_cache
-    assert len(list(jira.cache.root.iterdir())) == 2
-    for item in jira.cache.root.iterdir():
+def test_cache_exists(fake_jira):
+    assert str(fake_jira.cache.root) != ".jira_cache_test"
+    assert len(list(fake_jira.cache.root.iterdir())) == 2
+    for item in fake_jira.cache.root.iterdir():
         assert item.name in ("system", "issues")
-    assert len(list(jira.cache.system.iterdir())) == 1
-    for item in jira.cache.system.iterdir():
+    assert len(list(fake_jira.cache.system.iterdir())) == 1
+    for item in fake_jira.cache.system.iterdir():
         assert item.name in ("issue_type_fields")
-

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from mantis.drafts import Draft
@@ -6,8 +8,8 @@ from mantis.jira.jira_issues import JiraIssue
 
 
 @pytest.fixture
-def fake_jira(opts_from_fake_cli, mock_get_request):
-    expected = {
+def json_response(mock_get_request):
+    mock_get_request.return_value.json.return_value = {
         "key": "TASK-1",
         "fields": {
             "status": {"name": "resolved"},
@@ -17,25 +19,25 @@ def fake_jira(opts_from_fake_cli, mock_get_request):
             "assignee": {"displayName": "Bobby Goodsky"},
         },
     }
-    mock_get_request.return_value.json.return_value = expected
-    auth = JiraAuth(opts_from_fake_cli)
-    return JiraClient(opts_from_fake_cli, auth)
 
 
-def test_jira_draft(tmp_path, fake_jira: JiraClient):
-    drafts_dir = tmp_path / "drafts"
-    drafts_dir.mkdir()
+def test_jira_draft(fake_jira: JiraClient, json_response, with_fake_drafts_dir):
     fake_jira._no_cache = True
+    assert str(fake_jira.cache.root) != ".jira_cache_test"
+    assert str(fake_jira.drafts_dir) != "drafts_test"
+    # assert str(fake_jira.cache.root) != str(fake_jira.drafts_dir)
+    assert len(list(fake_jira.drafts_dir.iterdir())) == 0
+
+    # assert list(fake_jira.drafts_dir.iterdir())[0] == ""
     task_1 = fake_jira.issues.get("TASK-44")
     assert type(task_1) == JiraIssue
-    assert len(list(drafts_dir.iterdir())) == 0
-    draft = Draft(task_1, drafts_dir)
-    assert len([*drafts_dir.iterdir()]) == 1
+    draft = Draft(fake_jira, task_1)
+    assert len([*fake_jira.drafts_dir.iterdir()]) == 1
 
-    with open(drafts_dir / "TASK-1.md", "r") as f:
+    with open(fake_jira.drafts_dir / "TASK-1.md", "r") as f:
         content = f.read()
     assert "assignee: Bobby Goodsky" in content
-    assert "Bobby Goodsky" == draft.issue.get("fields", {}).get("assignee", {}).get(
+    assert "Bobby Goodsky" == draft.issue.get_field("assignee", {}).get(
         "displayName", ""
     )
     expectations = (
@@ -51,6 +53,7 @@ def test_jira_draft(tmp_path, fake_jira: JiraClient):
         "",
         "None",
     )
-    with open(drafts_dir / "TASK-1.md", "r") as f:
+    with open(fake_jira.drafts_dir / "TASK-1.md", "r") as f:
         for content, expected in zip(f.readlines(), expectations):
             assert content.strip() == expected
+


### PR DESCRIPTION
The fixtures have become a jumble of combined setup with very long names.

Instead of creating distinct fixtures for each conceivable scenario, we can break them down into smaller composable chunks like in the example below. More details in the [Pytest docs](https://docs.pytest.org/en/6.2.x/fixture.html#fixtures-can-be-requested-more-than-once-per-test-return-values-are-cached).

```python
@pytest.fixture
def with_no_cache(fake_jira):
    fake_jira._no_cache = True


@pytest.fixture
def with_fake_cache(opts_from_fake_cli, tmp_path: Path):
    (tmp_path / "cache").mkdir(exist_ok=True)
    opts_from_fake_cli.cache_dir = tmp_path / "cache"


@pytest.fixture
def with_fake_drafts_dir(fake_jira, tmp_path: Path):
    (tmp_path / "drafts").mkdir(exist_ok=True)
    fake_jira.drafts_dir = tmp_path / "drafts"


@pytest.fixture
def fake_jira(with_fake_cache, jira_client_from_fake_cli):
    jira = jira_client_from_fake_cli
    assert str(jira.cache.root) != ".jira_cache_test"
    return jira
```