### PR TITLE
Adding type hints for fake_jira in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def jira_client_from_fake_cli(opts_from_fake_cli):
 
 
 @pytest.fixture
-def with_no_cache(fake_jira):
+def with_no_cache(fake_jira: JiraClient):
     fake_jira._no_cache = True
 
 
@@ -94,13 +94,13 @@ def with_fake_cache(opts_from_fake_cli, tmp_path: Path):
 
 
 @pytest.fixture
-def with_fake_drafts_dir(fake_jira, tmp_path: Path):
+def with_fake_drafts_dir(fake_jira: JiraClient, tmp_path: Path):
     (tmp_path / "drafts").mkdir(exist_ok=True)
     fake_jira.drafts_dir = tmp_path / "drafts"
 
 
 @pytest.fixture
-def with_fake_plugins_dir(fake_jira, tmp_path: Path):
+def with_fake_plugins_dir(fake_jira: JiraClient, tmp_path: Path):
     (tmp_path / "plugins").mkdir(exist_ok=True)
     fake_jira.plugins_dir = tmp_path / "plugins"
 

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -21,11 +21,11 @@ def fake_jira_client_for_test_auth(opts_from_fake_cli, mock_get_request): # prag
 @pytest.mark.skipif(
     not os.getenv("EXECUTE_SKIPPED"), reason="This is a live test against the Jira api"
 )
-def test_jira_options_override(fake_jira_client_for_test_auth): # pragma: no cover
+def test_jira_options_override(fake_jira_client_for_test_auth: JiraClient): # pragma: no cover
     fake_jira_client_for_test_auth.test_auth()
 
 
-def test_cache_exists(fake_jira):
+def test_cache_exists(fake_jira: JiraClient):
     assert str(fake_jira.cache.root) != ".jira_cache_test"
     assert len(list(fake_jira.cache.root.iterdir())) == 2
     for item in fake_jira.cache.root.iterdir():
@@ -44,7 +44,7 @@ def json_response_account_id(mock_get_request):
     }
 
 
-def test_get_current_user(fake_jira, json_response_account_id):
+def test_get_current_user(fake_jira: JiraClient, json_response_account_id):
     assert fake_jira.get_current_user() == {
         "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
         "emailAddress": "user@domain.com",
@@ -52,27 +52,27 @@ def test_get_current_user(fake_jira, json_response_account_id):
     }
 
 
-def test_get_current_user_account_id(fake_jira, json_response_account_id):
+def test_get_current_user_account_id(fake_jira: JiraClient, json_response_account_id):
     assert (
         fake_jira.get_current_user_account_id()
         == "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"
     )
 
 
-def test_get_current_user_as_assignee(fake_jira, json_response_account_id):
+def test_get_current_user_as_assignee(fake_jira: JiraClient, json_response_account_id):
     assert fake_jira.get_current_user_as_assignee() == {
         "assignee": {"accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"}
     }
 
 
-def test_get_test_auth_success(fake_jira, json_response_account_id, capsys):
+def test_get_test_auth_success(fake_jira: JiraClient, json_response_account_id, capsys):
     assert fake_jira.test_auth()
     captured = capsys.readouterr()
     assert captured.out == "Connected as user: Marcus Aurelius\n"
     assert captured.err == ""
 
 
-def test_get_test_auth_connection_error(fake_jira, json_response_account_id, capsys):
+def test_get_test_auth_connection_error(fake_jira: JiraClient, json_response_account_id, capsys):
     with patch(
         "mantis.jira.jira_client.requests.get",
         side_effect=requests.exceptions.ConnectionError,
@@ -90,7 +90,7 @@ def test_get_test_auth_connection_error(fake_jira, json_response_account_id, cap
     assert captured.err == ""
 
 
-def test_get_test_auth_generic_exception(fake_jira, json_response_account_id, capsys):
+def test_get_test_auth_generic_exception(fake_jira: JiraClient, json_response_account_id, capsys):
     with patch(
         "mantis.jira.jira_client.requests.get",
         side_effect=requests.exceptions.RequestException,

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -51,7 +51,7 @@ def fake_jira_client_for_issue_type(opts_from_fake_cli, mock_get_request):
     return JiraClient(opts_from_fake_cli, auth)
 
 
-def test_fetch_issuetype_enums_mock(fake_jira_client_for_issue_type):
+def test_fetch_issuetype_enums_mock(fake_jira_client_for_issue_type: JiraClient):
     types_filter = lambda d: int(d["id"]) < 100 and d["name"] in (
         "Bug",
         "Task",
@@ -82,7 +82,7 @@ def test_fetch_issuetype_enums_mock(fake_jira_client_for_issue_type):
     ), "Issue of id == 1 has wrong description"
 
 
-def test_fetch_issuetype_enums_mock_no_casting(fake_jira_client_for_issue_type):
+def test_fetch_issuetype_enums_mock_no_casting(fake_jira_client_for_issue_type: JiraClient):
     types_filter = lambda d: d["id"] == 1
     mapping = {"id": "id", "description": "description", "untranslatedName": "name"}
     caster_functions = {}
@@ -103,7 +103,7 @@ def test_fetch_issuetype_enums_mock_no_casting(fake_jira_client_for_issue_type):
     ), "Issue of id == '1' has wrong description"
 
 
-def test_fetch_issuetype_enums_mock_no_mapping(fake_jira_client_for_issue_type):
+def test_fetch_issuetype_enums_mock_no_mapping(fake_jira_client_for_issue_type: JiraClient):
     types_filter = lambda d: d["id"] == 1
     mapping = {}
     caster_functions = {}

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -10,7 +10,7 @@ from mantis.jira import JiraAuth, JiraClient
 from mantis.jira.jira_issues import JiraIssues, process_key
 
 
-def test_jira_issues_get_fake(fake_jira):
+def test_jira_issues_get_fake(fake_jira: JiraClient):
     task_1 = fake_jira.issues.get("TASK-1")
     assert task_1.get("key") == "TASK-1"
     assert task_1.get("fields", {}).get("status") == {"name": "resolved"}
@@ -88,7 +88,7 @@ def test_jira_issues_get_real(jira_client_from_user_toml):
 
 
 @patch("mantis.jira.jira_client.requests.post")
-def test_jira_issues_create(mock_post, fake_jira):
+def test_jira_issues_create(mock_post, fake_jira: JiraClient):
     mock_post.return_value.json.return_value = {}
     with pytest.raises(ValueError):
         issue = fake_jira.issues.create(issue_type="Bug", title="Tester", data={})
@@ -136,14 +136,14 @@ def test_handle_http_error_raises_generic_exception(
                 fake_jira.issues.handle_http_error(exception=e, key="A-1")
 
 
-def test_jira_no_issues_fields_raises(fake_jira, mock_post_request):
+def test_jira_no_issues_fields_raises(fake_jira: JiraClient, mock_post_request):
     issue = fake_jira.issues.get("TASK-1")
     issue.data["fields"] = None
     with pytest.raises(KeyError):
         assert issue.fields
 
 
-def test_jira_issues_cached_issuetypes_parses_allowed_types(fake_jira):
+def test_jira_issues_cached_issuetypes_parses_allowed_types(fake_jira: JiraClient):
     fake_jira._no_cache = False
     cached_issuetypes = [{"id": 1, "name": "Bug"}, {"id": 2, "name": "Task"}]
     fake_jira.system_config_loader.get_issuetypes_names_from_cache = (


### PR DESCRIPTION
In order to get better tooling support, add type hints.