### PR TITLE
More granular requests mocks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,21 +94,29 @@ def with_fake_cache(opts_from_fake_cli, tmp_path: Path):
 
 
 @pytest.fixture
-def with_fake_drafts_dir(fake_jira: JiraClient, tmp_path: Path):
+def with_fake_drafts_dir(opts_from_fake_cli, tmp_path: Path):
     (tmp_path / "drafts").mkdir(exist_ok=True)
-    fake_jira.drafts_dir = tmp_path / "drafts"
+    opts_from_fake_cli.drafts_dir = tmp_path / "drafts"
 
 
 @pytest.fixture
-def with_fake_plugins_dir(fake_jira: JiraClient, tmp_path: Path):
+def with_fake_plugins_dir(opts_from_fake_cli, tmp_path: Path):
     (tmp_path / "plugins").mkdir(exist_ok=True)
-    fake_jira.plugins_dir = tmp_path / "plugins"
+    opts_from_fake_cli.plugins_dir = tmp_path / "plugins"
 
 
 @pytest.fixture
-def fake_jira(with_fake_cache, jira_client_from_fake_cli, mock_get_request):
+def fake_jira(
+    with_fake_cache,
+    with_fake_drafts_dir,
+    with_fake_plugins_dir,
+    jira_client_from_fake_cli,
+    mock_get_request,
+):
     jira = jira_client_from_fake_cli
     expected = {"key": "TASK-1", "fields": {"status": {"name": "resolved"}}}
     mock_get_request.return_value.json.return_value = expected
     assert str(jira.cache.root) != ".jira_cache_test"
+    assert str(jira.drafts_dir) != "drafts_test"
+    assert str(jira.plugins_dir) != "plugins_test"
     return jira

--- a/tests/test_jira_cache.py
+++ b/tests/test_jira_cache.py
@@ -3,7 +3,7 @@ import pytest
 from mantis.jira import JiraClient
 
 
-def test_cache_get_caches_jira_issue(with_fake_cache, fake_jira: JiraClient):
+def test_cache_get_caches_jira_issue(fake_jira: JiraClient):
     assert not fake_jira._no_cache
     with pytest.raises(FileNotFoundError) as exec_info:
         fake_jira.cache.get_decoded("issues/TASK-1.json")
@@ -16,9 +16,7 @@ def test_cache_get_caches_jira_issue(with_fake_cache, fake_jira: JiraClient):
     assert decoded == {"fields": {"status": {"name": "resolved"}}, "key": "TASK-1"}
 
 
-def test_cache_get_issue_returns_none_when_no_cache_is_set(
-    with_fake_cache, fake_jira: JiraClient
-):
+def test_cache_get_issue_returns_none_when_no_cache_is_set(fake_jira: JiraClient):
     # Make sure nothing is cached
     assert not fake_jira._no_cache
     nothing_1 = fake_jira.cache.get_issue("TASK-1")
@@ -36,7 +34,7 @@ def test_cache_get_issue_returns_none_when_no_cache_is_set(
     assert nothing_2 is None
 
 
-def test_cache_remove_does_removals(with_fake_cache, fake_jira: JiraClient):
+def test_cache_remove_does_removals(fake_jira: JiraClient):
     # cache something
     with open(fake_jira.cache.root / "issues/task-1.json", "w") as f:
         f.write('{"fields": {"status": {"name": "resolved"}}, "key": "task-1"}')
@@ -49,7 +47,7 @@ def test_cache_remove_does_removals(with_fake_cache, fake_jira: JiraClient):
     assert nothing_1 is None
 
 
-def test_cache_remove_issue_does_removals(with_fake_cache, fake_jira: JiraClient):
+def test_cache_remove_issue_does_removals(fake_jira: JiraClient):
     # cache something
     with open(fake_jira.cache.root / "issues/task-1.json", "w") as f:
         f.write('{"fields": {"status": {"name": "resolved"}}, "key": "task-1"}')
@@ -68,9 +66,7 @@ def test_cache_remove_issue_does_removals(with_fake_cache, fake_jira: JiraClient
         ("issue_type_fields"),
     ],
 )
-def test_cache_iter_dir_yields_files(
-    with_fake_cache, fake_jira: JiraClient, identifier: str
-):
+def test_cache_iter_dir_yields_files(fake_jira: JiraClient, identifier: str):
     assert len(list(fake_jira.cache.iter_dir(identifier))) == 0
     # cache something
     with open(fake_jira.cache.system / f"{identifier}/some_file.json", "w") as f:

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import pytest
 import requests
-from requests.exceptions import RequestException
 
 from mantis.jira import JiraAuth, JiraClient
 
@@ -95,7 +94,7 @@ def test_get_test_auth_generic_exception(fake_jira: JiraClient, json_response_ac
         "mantis.jira.jira_client.requests.get",
         side_effect=requests.exceptions.RequestException,
     ):
-        with pytest.raises(RequestException):
+        with pytest.raises(requests.exceptions.RequestException):
             fake_jira.test_auth()
     captured = capsys.readouterr()
     assert captured.out == ("test_auth failed for unknown reasons.\n")

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -1,27 +1,15 @@
-import os
 from unittest.mock import patch
 
 import pytest
 import requests
 
-from mantis.jira import JiraAuth, JiraClient
+from mantis.jira import JiraClient
 
 
-@pytest.fixture
-def fake_jira_client_for_test_auth(opts_from_fake_cli, mock_get_request): # pragma: no cover
-    mock_get_request.return_value.json.return_value = {}
-    auth = JiraAuth(opts_from_fake_cli)
-    return JiraClient(opts_from_fake_cli, auth)
-
-
-@pytest.mark.skipif(
-    not os.path.exists("options.toml"), reason='File "options.toml" does not exist'
-)
-@pytest.mark.skipif(
-    not os.getenv("EXECUTE_SKIPPED"), reason="This is a live test against the Jira api"
-)
-def test_jira_options_override(fake_jira_client_for_test_auth: JiraClient): # pragma: no cover
-    fake_jira_client_for_test_auth.test_auth()
+@patch("mantis.jira.jira_client.requests.get")
+def test_jira_options_override(mock_get, fake_jira: JiraClient):
+    mock_get.return_value.json.return_value = {}
+    fake_jira.test_auth()
 
 
 def test_cache_exists(fake_jira: JiraClient):

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -21,7 +21,7 @@ def json_response(mock_get_request):
     }
 
 
-def test_jira_draft(fake_jira: JiraClient, json_response, with_fake_drafts_dir):
+def test_jira_draft(fake_jira: JiraClient, json_response):
     fake_jira._no_cache = True
     assert str(fake_jira.cache.root) != ".jira_cache_test"
     assert str(fake_jira.drafts_dir) != "drafts_test"

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -153,7 +153,7 @@ def test_jira_issues_cached_issuetypes_parses_allowed_types(fake_jira: JiraClien
     assert fake_jira.issues.allowed_types == ["Bug", "Task"]
 
 
-def test_jira_issues_get_does_write_to_cache(with_fake_cache, fake_jira: JiraClient):
+def test_jira_issues_get_does_write_to_cache(fake_jira: JiraClient):
     fake_jira._no_cache = False
     assert fake_jira.cache.get_issue("TASK-1") is None
     assert len([file for file in fake_jira.cache.issues.iterdir()]) == 0
@@ -165,9 +165,7 @@ def test_jira_issues_get_does_write_to_cache(with_fake_cache, fake_jira: JiraCli
     assert data == {"fields": {"status": {"name": "resolved"}}, "key": "TASK-1"}
 
 
-def test_jira_issues_get_does_retrieve_from_cache(
-    with_fake_cache, fake_jira: JiraClient
-):
+def test_jira_issues_get_does_retrieve_from_cache(fake_jira: JiraClient):
     fake_jira._no_cache = False
     data = {"redacted": "True"}
     with open(fake_jira.cache.issues / "TASK-1.json", "w") as f:


### PR DESCRIPTION
Standardize on single `fake_jira` fixture.

Use `@patch` in individual tests to locally target `requests` to mock.