### PR TITLE
Use properties to make instantiations more readable

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -19,7 +19,6 @@ class JiraClient:
         self.options = jira_option
         self.auth = auth.auth
         self.no_verify_ssl = auth.no_verify_ssl
-        self.project_name = jira_option.project
         self._no_cache = no_cache
         self.requests_kwargs: dict[str, 'HTTPBasicAuth | bool | dict[str, Any]'] = {
             "auth": self.auth,
@@ -27,13 +26,23 @@ class JiraClient:
             "verify": (not self.no_verify_ssl),
         }
         self.cache = Cache(self)
-        self.drafts_dir = Path(self.options.drafts_dir)
         self.drafts_dir.mkdir(exist_ok=True)
-        self.plugins_dir = Path(self.options.plugins_dir)
         self.plugins_dir.mkdir(exist_ok=True)
         self.system_config_loader = JiraSystemConfigLoader(self)
         self.issues = JiraIssues(self)
 
+    @property
+    def drafts_dir(self) -> Path:
+        return Path(self.options.drafts_dir)
+
+    @property
+    def plugins_dir(self) -> Path:
+        return Path(self.options.plugins_dir)
+
+    @property
+    def project_name(self) -> str:
+        return self.options.project
+    
     @property
     def api_url(self) -> str:
         assert self.options.url

--- a/mantis/jira/utils/cache.py
+++ b/mantis/jira/utils/cache.py
@@ -14,17 +14,26 @@ class CacheMissException(Exception):
 class Cache:
     def __init__(self, jira_client: "JiraClient") -> None:
         self.client = jira_client
-
-        self.root = Path(self.client.options.cache_dir)
         self.root.mkdir(exist_ok=True)
-
-        self.issues = self.root / "issues"
         self.issues.mkdir(exist_ok=True)
-        self.system = self.root / "system"
         self.system.mkdir(exist_ok=True)
-        self.issue_type_fields = self.system / "issue_type_fields"
         self.issue_type_fields.mkdir(exist_ok=True)
 
+    @property
+    def root(self):
+        return Path(self.client.options.cache_dir)
+
+    @property
+    def issues(self):
+        return self.root / "issues"
+
+    @property
+    def system(self):
+        return self.root / "system"
+
+    @property
+    def issue_type_fields(self):
+        return self.system / "issue_type_fields"
     def get(self, file_name: str) -> str | None:
         if not (self.root / file_name).exists():
             return None

--- a/mantis/jira/utils/cache.py
+++ b/mantis/jira/utils/cache.py
@@ -20,20 +20,21 @@ class Cache:
         self.issue_type_fields.mkdir(exist_ok=True)
 
     @property
-    def root(self):
+    def root(self) -> Path:
         return Path(self.client.options.cache_dir)
 
     @property
-    def issues(self):
+    def issues(self) -> Path:
         return self.root / "issues"
 
     @property
-    def system(self):
+    def system(self) -> Path:
         return self.root / "system"
 
     @property
-    def issue_type_fields(self):
+    def issue_type_fields(self) -> Path:
         return self.system / "issue_type_fields"
+
     def get(self, file_name: str) -> str | None:
         if not (self.root / file_name).exists():
             return None


### PR DESCRIPTION
Tidy up the `__init__` of `Cache` and `JiraClient` by moving attributes to properties.