### PR TITLE
Default value overwrite None

### DIFF
--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -27,7 +27,7 @@ class Draft:
         summary = self.issue.get_field("summary")
         issuetype = self.issue.get_field("issuetype").get("name")
         assignee = self.issue.get_field("assignee", {})
-        assignee = assignee.get("displayName")
+        assignee_name = assignee.get("displayName")
         description = self.issue.get_field("description")
 
         with open(self.jira.drafts_dir / f"{key}.md", "w") as f:
@@ -38,7 +38,7 @@ class Draft:
             f.write(f"parent: {parent}\n")
             f.write(f"summary: {summary}\n")
             f.write(f"issuetype: {issuetype}\n")
-            f.write(f"assignee: {assignee}\n")
+            f.write(f"assignee: {assignee_name}\n")
             f.write("---\n")
             f.write(f"# {summary}\n")
             f.write("\n")

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -28,7 +28,7 @@ class JiraIssue:
         # https://docs.pydantic.dev/1.10/datamodel_code_generator/
 
     def get(self, key: str, default: Any = None) -> dict | None:
-        return self.data.get(key, default)
+        return self.data.get(key, default) or default
 
     @property
     def fields(self) -> dict:
@@ -39,7 +39,7 @@ class JiraIssue:
 
     def get_field(self, key: str, default: Any = None) -> Any:
         # Note that the key can exist and the value can still be None
-        return self.fields.get(key, default)
+        return self.fields.get(key, default) or default
 
 
 class JiraIssues:


### PR DESCRIPTION
When the key exists in a dict and the key refers to `None`, then the value returned from `get(key, default)` will be `None`, even if a `default` is provided. To get around this, we introduce an explicit overwrite.

```diff
      def get(self, key: str, default: Any = None) -> dict | None:
-         return self.data.get(key, default)
+         return self.data.get(key, default) or default
```

This means that we can rely on the default value of `{}` as below, without worrying about `assignee_name` being `None`.

```python
        assignee = self.issue.get_field("assignee", {})
        assignee_name = assignee.get("displayName")
```