### PR TITLE
Make properties of cache data attributes

### DIFF
--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -4,41 +4,67 @@ from .update_projects_cache_response import update_projects_cache_response
 from .get_issuetypes_response import get_issuetypes_response
 
 class CacheData:
-    with open('tests/data/jira_cache/issues/ECS-1.json', 'r') as f:
-        ecs_1 = json.load(f)
+    @property
+    def ecs_1(self):
+        with open('tests/data/jira_cache/issues/ECS-1.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/issues/ECS-2.json', 'r') as f:
-        ecs_2 = json.load(f)
+    @property
+    def ecs_2(self):
+        with open('tests/data/jira_cache/issues/ECS-2.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/issues/ECS-3.json', 'r') as f:
-        ecs_3 = json.load(f)
+    @property
+    def ecs_3(self):
+        with open('tests/data/jira_cache/issues/ECS-3.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/issues/ECS-4.json', 'r') as f:
-        ecs_4 = json.load(f)
+    @property
+    def ecs_4(self):
+        with open('tests/data/jira_cache/issues/ECS-4.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/issues/ECS-5.json', 'r') as f:
-        ecs_5 = json.load(f)
+    @property
+    def ecs_5(self):
+        with open('tests/data/jira_cache/issues/ECS-5.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/issues/ECS-6.json', 'r') as f:
-        ecs_6 = json.load(f)
+    @property
+    def ecs_6(self):
+        with open('tests/data/jira_cache/issues/ECS-6.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/system/issuetypes.json', 'r') as f:
-        issuetypes = json.load(f)
+    @property
+    def issuetypes(self):
+        with open('tests/data/jira_cache/system/issuetypes.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/system/projects.json', 'r') as f:
-        projects = json.load(f)
+    @property
+    def projects(self):
+        with open('tests/data/jira_cache/system/projects.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/system/issuetype_fields/createmeta_bug.json', 'r') as f:
-        createmeta_bug = json.load(f)
+    @property
+    def createmeta_bug(self):
+        with open('tests/data/jira_cache/system/issuetype_fields/createmeta_bug.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/system/issuetype_fields/createmeta_epic.json', 'r') as f:
-        createmeta_epic = json.load(f)
+    @property
+    def createmeta_epic(self):
+        with open('tests/data/jira_cache/system/issuetype_fields/createmeta_epic.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/system/issuetype_fields/createmeta_story.json', 'r') as f:
-        createmeta_story = json.load(f)
+    @property
+    def createmeta_story(self):
+        with open('tests/data/jira_cache/system/issuetype_fields/createmeta_story.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/system/issuetype_fields/createmeta_subtask.json', 'r') as f:
-        createmeta_subtask = json.load(f)
+    @property
+    def createmeta_subtask(self):
+        with open('tests/data/jira_cache/system/issuetype_fields/createmeta_subtask.json', 'r') as f:
+            return json.load(f)
 
-    with open('tests/data/jira_cache/system/issuetype_fields/createmeta_task.json', 'r') as f:
-        createmeta_task = json.load(f)
+    @property
+    def createmeta_task(self):
+        with open('tests/data/jira_cache/system/issuetype_fields/createmeta_task.json', 'r') as f:
+            return json.load(f)

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -25,11 +25,11 @@ def test_config_loader_update_issuetypes_writes_to_cache(
 
 
 def test_persisted_issuetypes_data():
-    assert hasattr(CacheData, 'issuetypes')
-    selector = lambda field_name: [_[field_name] for _ in CacheData.issuetypes]
-    assert len(CacheData.issuetypes) == 5
-    assert selector('name') == ['Subtask', 'Story', 'Bug', 'Task', 'Epic']
-    assert CacheData.issuetypes[0].get('scope') == {"type": "PROJECT", "project": {"id": "10000"}}
+    cache_data = CacheData()
+    assert hasattr(cache_data, 'issuetypes')
+    selector = lambda field_name: {_[field_name] for _ in cache_data.issuetypes}
+    assert len(cache_data.issuetypes) == 5
+    assert selector('name') == {'Subtask', 'Story', 'Bug', 'Task', 'Epic'}
 
 
 @patch("mantis.jira.jira_client.requests.get")
@@ -37,7 +37,7 @@ def test_cache_get_issuetypes_from_system_cache(mock_get, fake_jira: JiraClient)
     mock_get.return_value.json.return_value = get_issuetypes_response
     cache = fake_jira.cache
     with open(fake_jira.cache.system / "issuetypes.json", "w") as f:
-        json.dump(CacheData.issuetypes, f)
+        json.dump(CacheData().issuetypes, f)
     retrieved = cache.get_issuetypes_from_system_cache()
     assert retrieved
     assert retrieved[0].get("description") == (


### PR DESCRIPTION
To ensure test values are not reused, turn them into properties that read from disk every time.