### PR TITLE
Revamped update project field keys

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -83,6 +83,15 @@ class JiraClient:
         url = f"{self.api_url}/{uri}"
         return requests.put(url, json=data, **self.requests_kwargs)  # type: ignore
 
+    def get_createmeta(self, project_name: str, issuetype_id: str) -> requests.Response:
+        url = (
+            "issue/createmeta"
+            f"/{project_name}"
+            "/issuetypes/"
+            f"{issuetype_id}"
+        )
+        return self._get(url)
+
     def get_issue(self, key: str) -> requests.Response:
         return self._get(f"issue/{key}")
 

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -54,20 +54,24 @@ class JiraIssues:
     def __init__(self, client: "JiraClient"):
         self.client = client
 
-    def load_allowed_types(self) -> None:
-        cached_issuetypes = (
+    def load_allowed_types(self) -> list[str]:
+        issuetypes = (
             self.client.system_config_loader.get_issuetypes_for_project()
         )
-        if not cached_issuetypes:
-            return None
-        assert isinstance(cached_issuetypes, list)
-        assert isinstance(cached_issuetypes[0], dict)
-        assert isinstance(cached_issuetypes[0]["id"], str), f'Unexpected type of cached_issuetypes[0]["id"]: {cached_issuetypes[0]["id"]} ({type(cached_issuetypes[0]["id"])})'
-        sorted_cached_issuetypes = sorted(
-            cached_issuetypes, key=lambda x: str(x.get("id"))
+        if not issuetypes:
+            raise ValueError('No values retrieved for issuetypes')
+        assert isinstance(issuetypes, dict)
+        nested_issuetypes: list[dict] = issuetypes['issueTypes']
+        assert isinstance(nested_issuetypes, list), f"nested_issuetypes: {nested_issuetypes}"
+        assert isinstance(nested_issuetypes[0], dict)
+        assert isinstance(nested_issuetypes[0]["id"], str), f'Unexpected type of nested_issuetypes[0]["id"]: {nested_issuetypes[0]["id"]} ({type(nested_issuetypes[0]["id"])})'
+        sorted_nested_issuetypes = sorted(
+            nested_issuetypes, key=lambda x: str(x.get("id"))
         )
-        assert len(sorted_cached_issuetypes), 'List sorted_cached_issuetypes must not be empty'
-        self._allowed_types = [_.get("name", '') for _ in sorted_cached_issuetypes]
+        assert len(sorted_nested_issuetypes), 'List sorted_nested_issuetypes must not be empty'
+        self._allowed_types = [_.get("name", '') for _ in sorted_nested_issuetypes]
+        assert self._allowed_types
+        return self._allowed_types
 
     @property
     def allowed_types(self) -> list[str] | None:

--- a/mantis/jira/utils/cache.py
+++ b/mantis/jira/utils/cache.py
@@ -68,13 +68,13 @@ class Cache:
             raise LookupError('Attempted to access cache when _no_read_cache is set')
         return self.get_from_system_cache(f"projects.json")
 
-    def get_issuetypes_from_system_cache(self) -> list[dict[str, Any]] | None:
+    def get_issuetypes_from_system_cache(self) -> dict[str, Any] | None:
         if self.client._no_read_cache:
             raise LookupError('Attempted to access cache when _no_read_cache is set')
         issuetypes = self.get_from_system_cache("issuetypes.json")
         if not issuetypes:
             return None
-        assert isinstance(issuetypes, list), f'{issuetypes} should be of type list. Got: {type(issuetypes)}'
+        assert isinstance(issuetypes, dict), f'{issuetypes} should be of type dict. Got: {type(issuetypes)}: {issuetypes}'
         return issuetypes
 
     def get_from_issuetype_fields_cache(self, filename: str) -> dict[str, Any] | None:
@@ -102,7 +102,7 @@ class Cache:
     def write_to_system_cache(self, filename: str, issue_enums: str) -> None:
         self._write(self.system, filename, issue_enums)
 
-    def write_issuetypes_to_system_cache(self, issuetypes: list[dict[str, Any]]) -> None:
+    def write_issuetypes_to_system_cache(self, issuetypes: dict[str, Any]) -> None:
         self.write_to_system_cache("issuetypes.json", json.dumps(issuetypes))
 
     def write_to_issuetype_fields(self, filename: str, issuetype_fields: list[dict[str, Any]]) -> None:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -48,7 +48,7 @@ class JiraSystemConfigLoader:
         return self.update_projects_cache()
 
     def update_issuetypes_cache(self) -> list[dict[str, Any]]:
-        url = 'issuetype'
+        url = f'issue/createmeta/{self.client.project_name}/issuetypes'
         response = self.client._get(url)
         try:
             response.raise_for_status()

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -47,7 +47,7 @@ class JiraSystemConfigLoader:
                 return projects
         return self.update_projects_cache()
 
-    def update_issuetypes_cache(self) -> list[dict[str, Any]]:
+    def update_issuetypes_cache(self) -> dict[str, Any]:
         url = f'issue/createmeta/{self.client.project_name}/issuetypes'
         response = self.client._get(url)
         try:
@@ -57,22 +57,23 @@ class JiraSystemConfigLoader:
             print(e.response.content)
             exit()
 
-        issuetypes: list[dict[str, Any]] = response.json()
-        assert isinstance(issuetypes, list)
+        issuetypes: dict[str, Any] = response.json()
+        assert isinstance(issuetypes, dict), f'issuetypes is not a dict: {issuetypes}'
+        assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got: {issuetypes}"
+        assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
 
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 
-    def get_issuetypes(self) -> list[dict[str, Any]]:
+    def get_issuetypes(self) -> dict[str, Any]:
         if not self.client._no_read_cache:
             from_cache = self.cache.get_issuetypes_from_system_cache()
             if from_cache:
                 return from_cache
         return self.update_issuetypes_cache()
 
-    def get_issuetypes_for_project(self) -> list[dict[str, Any]]:
-        data = [_ for _ in self.get_issuetypes()
-                if _.get('scope', {}).get('project', {}).get('id') == self.client.project_id]
+    def get_issuetypes_for_project(self) -> dict[str, Any]:
+        data = self.get_issuetypes()
         self.cache.write_issuetypes_to_system_cache(data)
         try:
             assert len(data)
@@ -80,26 +81,24 @@ class JiraSystemConfigLoader:
             raise ValueError('List of issuetypes has length of zero. Something is probably very wrong.') from e
         return data
 
-    def update_project_field_keys(self) -> list[str] | None:
-        issuetypes = self.get_issuetypes_for_project()
-        if not issuetypes:
-            raise ValueError('Issue types not initialized')
+    def update_project_field_keys(self) -> list[str]:
+        issuetypes: dict[str, Any] = self.get_issuetypes_for_project()
 
-        names = [_['name'] for _ in issuetypes]
-        for issuetype in names:
-            # assert issuetype in names, f'issuetypes not in names: "{issuetype}" in {names}'
-            type_id = [_['id'] for _ in issuetypes if _['name'] == issuetype][0]
-            url = (
-                "issue/createmeta"
-                f"/{self.client.project_name}"
-                "/issuetypes/"
-                f"{type_id}"
-            )
-            response = self.client._get(url)
+        assert isinstance(issuetypes, dict)#
+        assert 'issueTypes' in issuetypes, f'issueTypes has no issueTypes {issuetypes}'
+
+        nested_issuetypes: list[dict[str, Any]] = issuetypes['issueTypes']
+
+        for issuetype in nested_issuetypes:
+            assert 'name' in issuetype.keys()
+            assert 'id' in issuetype.keys()
+            issuetype_name = issuetype['name']
+            issuetype_id = issuetype['id']
+            response = self.client.get_createmeta(self.client.project_name, issuetype_id)
             response.raise_for_status()
             data: list[dict[str, Any]] = response.json()
-            self.cache.write_createmeta(issuetype, data)
-        return self.client.issues.allowed_types
+            self.cache.write_createmeta(issuetype_name, data)
+        return self.client.issues.load_allowed_types()
 
     def compile_plugins(self) -> None:
         for input_file in self.cache.iter_dir("issuetype_fields"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ def fake_jira(
     mock_get_request,
 ):
     jira = jira_client_from_fake_cli
-    expected = {"key": "TASK-1", "fields": {"status": {"name": "resolved"}}}
+    expected = {"key": "TASK-1", "fields": {"status": {"name": "resolved"}, "description": "redacted"}}
     mock_get_request.return_value.json.return_value = expected
     assert str(jira.cache.root) != ".jira_cache_test"
     assert str(jira.drafts_dir) != "drafts_test"

--- a/tests/data/get_issuetypes_response.py
+++ b/tests/data/get_issuetypes_response.py
@@ -1,176 +1,181 @@
-get_issuetypes_response = [
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/99999",
-        "id": "99999",
-        "description": "Fake type for testing.",
-        "iconUrl": "https://notreal.com",
-        "name": "Testtype",
-        "untranslatedName": "Testtype",
-        "subtask": False,
-        "avatarId": 99999,
-        "hierarchyLevel": -1,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
+get_issuetypes_response = {
+    "startAt": 0,
+    "maxResults": 50,
+    "total": 5,
+    "issueTypes": [
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/99999",
+            "id": "99999",
+            "description": "Fake type for testing.",
+            "iconUrl": "https://notreal.com",
+            "name": "Testtype",
+            "untranslatedName": "Testtype",
+            "subtask": False,
+            "avatarId": 99999,
+            "hierarchyLevel": -1,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10009",
+            "id": "10009",
+            "description": "Subtasks track small pieces of work that are part of a larger task.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium",
+            "name": "Subtask",
+            "untranslatedName": "Subtask",
+            "subtask": True,
+            "avatarId": 10316,
+            "hierarchyLevel": -1,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10001"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10002",
+            "id": "10002",
+            "description": "Subtasks track small pieces of work that are part of a larger task.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium",
+            "name": "Subtask",
+            "untranslatedName": "Subtask",
+            "subtask": True,
+            "avatarId": 10316,
+            "hierarchyLevel": -1,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10004",
+            "id": "10004",
+            "description": "Stories track functionality or features expressed as user goals.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium",
+            "name": "Story",
+            "untranslatedName": "Story",
+            "subtask": False,
+            "avatarId": 10315,
+            "hierarchyLevel": 0,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10005",
+            "id": "10005",
+            "description": "Bugs track problems or errors.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium",
+            "name": "Bug",
+            "untranslatedName": "Bug",
+            "subtask": False,
+            "avatarId": 10303,
+            "hierarchyLevel": 0,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10003",
+            "id": "10003",
+            "description": "Tasks track small, distinct pieces of work.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+            "name": "Task",
+            "untranslatedName": "Task",
+            "subtask": False,
+            "avatarId": 10318,
+            "hierarchyLevel": 0,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10007",
+            "id": "10007",
+            "description": "Stories track functionality or features expressed as user goals.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10300?size=medium",
+            "name": "Story",
+            "untranslatedName": "Story",
+            "subtask": False,
+            "avatarId": 10300,
+            "hierarchyLevel": 0
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10006",
+            "id": "10006",
+            "description": "Tasks track small, distinct pieces of work.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+            "name": "Task",
+            "untranslatedName": "Task",
+            "subtask": False,
+            "avatarId": 10318,
+            "hierarchyLevel": 0,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10001"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10001",
+            "id": "10001",
+            "description": "Epics track collections of related bugs, stories, and tasks.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10307?size=medium",
+            "name": "Epic",
+            "untranslatedName": "Epic",
+            "subtask": False,
+            "avatarId": 10307,
+            "hierarchyLevel": 1,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10000",
+            "id": "10000",
+            "description": "A big user story that needs to be broken down. Created by Jira Software - do not edit or delete.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/images/icons/issuetypes/epic.svg",
+            "name": "Epic",
+            "untranslatedName": "Epic",
+            "subtask": False,
+            "hierarchyLevel": 1
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10008",
+            "id": "10008",
+            "description": "Epics track collections of related bugs, stories, and tasks.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10307?size=medium",
+            "name": "Epic",
+            "untranslatedName": "Epic",
+            "subtask": False,
+            "avatarId": 10307,
+            "hierarchyLevel": 1,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10001"
+                }
             }
         }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10009",
-        "id": "10009",
-        "description": "Subtasks track small pieces of work that are part of a larger task.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium",
-        "name": "Subtask",
-        "untranslatedName": "Subtask",
-        "subtask": True,
-        "avatarId": 10316,
-        "hierarchyLevel": -1,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10001"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10002",
-        "id": "10002",
-        "description": "Subtasks track small pieces of work that are part of a larger task.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium",
-        "name": "Subtask",
-        "untranslatedName": "Subtask",
-        "subtask": True,
-        "avatarId": 10316,
-        "hierarchyLevel": -1,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10004",
-        "id": "10004",
-        "description": "Stories track functionality or features expressed as user goals.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium",
-        "name": "Story",
-        "untranslatedName": "Story",
-        "subtask": False,
-        "avatarId": 10315,
-        "hierarchyLevel": 0,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10005",
-        "id": "10005",
-        "description": "Bugs track problems or errors.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium",
-        "name": "Bug",
-        "untranslatedName": "Bug",
-        "subtask": False,
-        "avatarId": 10303,
-        "hierarchyLevel": 0,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10003",
-        "id": "10003",
-        "description": "Tasks track small, distinct pieces of work.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
-        "name": "Task",
-        "untranslatedName": "Task",
-        "subtask": False,
-        "avatarId": 10318,
-        "hierarchyLevel": 0,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10007",
-        "id": "10007",
-        "description": "Stories track functionality or features expressed as user goals.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10300?size=medium",
-        "name": "Story",
-        "untranslatedName": "Story",
-        "subtask": False,
-        "avatarId": 10300,
-        "hierarchyLevel": 0
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10006",
-        "id": "10006",
-        "description": "Tasks track small, distinct pieces of work.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
-        "name": "Task",
-        "untranslatedName": "Task",
-        "subtask": False,
-        "avatarId": 10318,
-        "hierarchyLevel": 0,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10001"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10001",
-        "id": "10001",
-        "description": "Epics track collections of related bugs, stories, and tasks.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10307?size=medium",
-        "name": "Epic",
-        "untranslatedName": "Epic",
-        "subtask": False,
-        "avatarId": 10307,
-        "hierarchyLevel": 1,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10000",
-        "id": "10000",
-        "description": "A big user story that needs to be broken down. Created by Jira Software - do not edit or delete.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/images/icons/issuetypes/epic.svg",
-        "name": "Epic",
-        "untranslatedName": "Epic",
-        "subtask": False,
-        "hierarchyLevel": 1
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/3/issuetype/10008",
-        "id": "10008",
-        "description": "Epics track collections of related bugs, stories, and tasks.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10307?size=medium",
-        "name": "Epic",
-        "untranslatedName": "Epic",
-        "subtask": False,
-        "avatarId": 10307,
-        "hierarchyLevel": 1,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10001"
-            }
-        }
-    }
-]
+    ]
+}

--- a/tests/data/jira_cache/system/issuetypes.json
+++ b/tests/data/jira_cache/system/issuetypes.json
@@ -1,87 +1,87 @@
-[
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10002",
-        "id": "10002",
-        "description": "Subtasks track small pieces of work that are part of a larger task.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium",
-        "name": "Subtask",
-        "untranslatedName": "Subtask",
-        "subtask": true,
-        "avatarId": 10316,
-        "hierarchyLevel": -1,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
+{
+    "startAt": 0,
+    "maxResults": 50,
+    "total": 5,
+    "issueTypes": [
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10001",
+            "id": "10001",
+            "description": "Epics track collections of related bugs, stories, and tasks.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10307?size=medium",
+            "name": "Epic",
+            "untranslatedName": "Epic",
+            "subtask": false,
+            "hierarchyLevel": 1,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10002",
+            "id": "10002",
+            "description": "Subtasks track small pieces of work that are part of a larger task.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium",
+            "name": "Subtask",
+            "untranslatedName": "Subtask",
+            "subtask": true,
+            "hierarchyLevel": -1,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10003",
+            "id": "10003",
+            "description": "Tasks track small, distinct pieces of work.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+            "name": "Task",
+            "untranslatedName": "Task",
+            "subtask": false,
+            "hierarchyLevel": 0,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10004",
+            "id": "10004",
+            "description": "Stories track functionality or features expressed as user goals.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium",
+            "name": "Story",
+            "untranslatedName": "Story",
+            "subtask": false,
+            "hierarchyLevel": 0,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
+            }
+        },
+        {
+            "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10005",
+            "id": "10005",
+            "description": "Bugs track problems or errors.",
+            "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium",
+            "name": "Bug",
+            "untranslatedName": "Bug",
+            "subtask": false,
+            "hierarchyLevel": 0,
+            "scope": {
+                "type": "PROJECT",
+                "project": {
+                    "id": "10000"
+                }
             }
         }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10004",
-        "id": "10004",
-        "description": "Stories track functionality or features expressed as user goals.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium",
-        "name": "Story",
-        "untranslatedName": "Story",
-        "subtask": false,
-        "avatarId": 10315,
-        "hierarchyLevel": 0,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10005",
-        "id": "10005",
-        "description": "Bugs track problems or errors.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium",
-        "name": "Bug",
-        "untranslatedName": "Bug",
-        "subtask": false,
-        "avatarId": 10303,
-        "hierarchyLevel": 0,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10003",
-        "id": "10003",
-        "description": "Tasks track small, distinct pieces of work.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
-        "name": "Task",
-        "untranslatedName": "Task",
-        "subtask": false,
-        "avatarId": 10318,
-        "hierarchyLevel": 0,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    },
-    {
-        "self": "https://caspertestaccount.atlassian.net/rest/api/2/issuetype/10001",
-        "id": "10001",
-        "description": "Epics track collections of related bugs, stories, and tasks.",
-        "iconUrl": "https://caspertestaccount.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10307?size=medium",
-        "name": "Epic",
-        "untranslatedName": "Epic",
-        "subtask": false,
-        "avatarId": 10307,
-        "hierarchyLevel": 1,
-        "scope": {
-            "type": "PROJECT",
-            "project": {
-                "id": "10000"
-            }
-        }
-    }
-]
+    ]
+}

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -27,8 +27,8 @@ def test_config_loader_update_issuetypes_writes_to_cache(
 def test_persisted_issuetypes_data():
     cache_data = CacheData()
     assert hasattr(cache_data, 'issuetypes')
-    selector = lambda field_name: {_[field_name] for _ in cache_data.issuetypes}
-    assert len(cache_data.issuetypes) == 5
+    selector = lambda field_name: {_[field_name] for _ in cache_data.issuetypes.get("issueTypes")}
+    assert len(cache_data.issuetypes.get("issueTypes")) == 5
     assert selector('name') == {'Subtask', 'Story', 'Bug', 'Task', 'Epic'}
 
 
@@ -40,8 +40,12 @@ def test_cache_get_issuetypes_from_system_cache(mock_get, fake_jira: JiraClient)
         json.dump(CacheData().issuetypes, f)
     retrieved = cache.get_issuetypes_from_system_cache()
     assert retrieved
-    assert retrieved[0].get("description") == (
-        "Subtasks track small pieces of work that are part of a larger task.")
+    assert retrieved['issueTypes'][0].get("description") in (
+            "Subtasks track small pieces of work that are part of a larger task.",
+            "Epics track collections of related bugs, stories, and tasks."
+        ), (
+            f'retrieved: {retrieved}'
+        )
 
 
 @patch("mantis.jira.jira_client.requests.get")
@@ -58,46 +62,78 @@ def test_config_loader_loop_yields_files(mock_get, fake_jira: JiraClient):
 @patch("mantis.jira.jira_client.requests.get")
 def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
     config_loader = fake_jira.system_config_loader
+
+    # Mock projects response
+    mock_get.return_value.json.return_value = update_projects_cache_response
+
+    # Test initial state
     if (fake_jira.cache.system / 'projects.json').exists():
         raise FileExistsError('File "projects.json" should not exist yet')
-    mock_get.return_value.json.return_value = update_projects_cache_response
+    assert fake_jira._project_id == None
+
+    # Fetch and cache projects data (without updating the object)
     got_projects = config_loader.update_projects_cache()
-    assert all({int(_['id']) in list(range(10000, 10010)) + [99999] for _ in got_projects}), (
-        'We expect two projects in len(update_projects_cache_response): '
-        f'{len(update_projects_cache_response)} Got {[_['id'] for _ in got_projects]}')
+    assert isinstance(got_projects, list)
+    assert len(got_projects) == 2
+    assert {_['id'] for _ in got_projects} == {'10000', '10001'}
+
+    # Check side-effect
     if not (fake_jira.cache.system / 'projects.json').exists():
         raise FileNotFoundError('File "projects.json" should have been created')
+    # Note: Private jira._project_id is still None, even after the file has been written.
+    assert fake_jira._project_id == None
+    # Note: Only once the public jira.project_id is queried does the private one get updated
+    assert fake_jira.project_id == '10000'
+    assert fake_jira._project_id == '10000'
+    
+    # Test projects response
+    got_project_ids_as_ints = {int(_['id']) for _ in got_projects}
+    expected_project_ids = {10000, 10001}
+    assert got_project_ids_as_ints == expected_project_ids, (
+        'We expect two projects in len(update_projects_cache_response): '
+        f'{len(update_projects_cache_response)} Got {got_project_ids_as_ints}')
+    
+    # Mock issuetypes response
+    mock_get.return_value.json.return_value = CacheData().issuetypes
 
+    # Fetch and cache issuetypes data
     if (fake_jira.cache.system / 'issuetypes.json').exists():
         raise FileExistsError('File "issuetypes.json" should not exist yet')
-    mock_get.return_value.json.return_value = get_issuetypes_response
     got_issue_types = config_loader.get_issuetypes()
-    assert all({int(_['id']) in list(range(10000, 10010)) + [99999] for _ in got_issue_types}), (
-        f'Issue types: {[_['id'] for _ in got_issue_types]}')
+    assert isinstance(got_issue_types, dict)
+    assert 'issueTypes' in got_issue_types
+    assert isinstance(got_issue_types['issueTypes'], list)
+    expected_issue_ids: set[int] = set(list(range(10001, 10006)))
+    got_issue_ids_as_ints = {int(_['id']) for _ in got_issue_types['issueTypes']}
+
+    assert len(got_issue_types['issueTypes']) == 5 #, f'{len(got_issue_types)} {got_issue_types}'
+    assert got_issue_ids_as_ints == expected_issue_ids, (
+        f'Issue types: {got_issue_ids_as_ints}')
     if not (fake_jira.cache.system / 'issuetypes.json').exists():
         raise FileNotFoundError('File "issuetypes.json" should have been created')
 
-    mock_get.return_value.json.return_value = {"name": "Testtype"}
+    mock_get.return_value.json.return_value = {'issueTypes': {"name": "Testtype"}}
 
-    if (fake_jira.cache.issuetype_fields / 'createmeta_testtype.json').exists():
-        raise FileExistsError('File "createmeta_testtype.json" should not exist yet')
+    if (fake_jira.cache.issuetype_fields / 'createmeta_story.json').exists():
+        raise FileExistsError('File "createmeta_story.json" should not exist yet')
     allowed_types = config_loader.update_project_field_keys()
-    if not (fake_jira.cache.issuetype_fields / 'createmeta_testtype.json').exists():
-        raise FileNotFoundError('File "createmeta_testtype.json" should have been created')
-    assert 'Testtype' in (allowed_types or []), f"Testtype not in allowed_types: {allowed_types}"
-    with open(fake_jira.cache.issuetype_fields / "createmeta_testtype.json", "r") as f:
-        assert f.read() == '{"name": "Testtype"}'
+    assert set(allowed_types) == set(['Epic', 'Subtask', 'Task', 'Story', 'Bug'])
+    if not (fake_jira.cache.issuetype_fields / 'createmeta_story.json').exists():
+        raise FileNotFoundError('File "createmeta_story.json" should have been created')
+    assert 'Story' in (allowed_types or []), f"Testtype not in allowed_types: {allowed_types}"
+    with open(fake_jira.cache.issuetype_fields / "createmeta_story.json", "r") as f:
+        assert f.read() == '{"issueTypes": {"name": "Testtype"}}'
 
 
 @patch("mantis.jira.jira_client.requests.get")
 def test_compile_plugins(mock_get, fake_jira: JiraClient):
-    mock_get.return_value.json.return_value = {"name": "test_type"}
+    mock_get.return_value.json.return_value = {"name": "Testtype"}
     assert str(fake_jira.plugins_dir) != ".jira_cache_test"
 
     config_loader = fake_jira.system_config_loader
 
-    with open(fake_jira.cache.issuetype_fields / "test_type.json", "w") as f:
-        f.write('{"name": "test_type"}')
+    with open(fake_jira.cache.issuetype_fields / "Testtype.json", "w") as f:
+        f.write('{"name": "Testtype"}')
 
     assert (
         len(list(fake_jira.plugins_dir.iterdir())) == 0

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -18,7 +18,7 @@ def test_jira_issues_get_fake(fake_jira: JiraClient):
 
 def test_jira_issues_get_mocked(fake_jira: JiraClient, with_no_read_cache):
     assert fake_jira._no_read_cache is True
-    expected = {"key": "TASK-1", "fields": {"status": {"name": "resolved"}}}
+    expected = {"key": "TASK-1", "fields": {"status": {"name": "resolved"}, "description": "redacted"}}
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.ok = True
@@ -144,8 +144,12 @@ def test_jira_no_issues_fields_raises(fake_jira: JiraClient, mock_post_request):
 
 
 def test_jira_issues_cached_issuetypes_parses_allowed_types(fake_jira: JiraClient):
-    cached_issuetypes = [{"id": '1', "name": "Bug", 'scope': {'project': {'id': '10000'}}},
-                         {"id": '2', "name": "Task", 'scope': {'project': {'id': '10000'}}}]
+    cached_issuetypes = {
+        "issueTypes": [
+            {"id": '1', "name": "Bug", 'scope': {'project': {'id': '10000'}}},
+            {"id": '2', "name": "Task", 'scope': {'project': {'id': '10000'}}}
+        ]
+    }
     fake_jira.system_config_loader.get_issuetypes_for_project = (
         lambda *args, **kwargs: cached_issuetypes
     )
@@ -162,7 +166,7 @@ def test_jira_issues_get_does_write_to_cache(fake_jira: JiraClient):
     assert len([file for file in fake_jira.cache.issues.iterdir()]) == 1
     with open(fake_jira.cache.issues / "TASK-1.json", "r") as f:
         data = json.load(f)
-    assert data == {"fields": {"status": {"name": "resolved"}}, "key": "TASK-1"}
+    assert data == {"fields": {"status": {"name": "resolved"}, "description": "redacted"}, "key": "TASK-1"}
 
 
 def test_jira_issues_get_does_retrieve_from_cache(fake_jira: JiraClient):


### PR DESCRIPTION
Change the url for `update_issuetypes_cache` to use the project specific version.

```diff
-     def update_issuetypes_cache(self) -> list[dict[str, Any]]:
-         url = 'issuetype'
+     def update_issuetypes_cache(self) -> dict[str, Any]:
+         url = f'issue/createmeta/{self.client.project_name}/issuetypes'
```

The resulting change of types cascades through the repo.