### PR TITLE
Ensure optional allowed_types is always set to a value

### DIFF
--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -99,7 +99,7 @@ class JiraIssues:
         return JiraIssue(self.client, issue_data)
 
     def create(self, issuetype: str, title: str, data: dict) -> dict:
-        assert self.allowed_types and issuetype in self.allowed_types
+        assert issuetype in self.allowed_types
         if len(data.keys()) == 0:
             raise ValueError("The data object is an empty payload")
         print(f"Create issue ({issuetype}): {title}")

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -77,9 +77,11 @@ class JiraIssues:
         return self._allowed_types
 
     @property
-    def allowed_types(self) -> list[str] | None:
+    def allowed_types(self) -> list[str]:
         if self._allowed_types is None:
             self.load_allowed_types()
+            if self._allowed_types is None:
+                raise ValueError('Loading allowed_types failed.')
         return self._allowed_types
 
     def get(self, key: str) -> JiraIssue:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -166,7 +166,7 @@ class JiraSystemConfigLoader:
 
     def get_project_field_keys_from_cache(self) -> Dict[str, ProjectFieldKeys]:
         d: Dict[str, ProjectFieldKeys] = {}
-        for issuetype in self.client.issues.allowed_types or []:
+        for issuetype in self.client.issues.allowed_types:
             try:
                 loaded_json = self.cache.get_createmeta_from_issuetype_fields_cache(issuetype)
                 issuetype_fields = IssueTypeFields.model_validate(loaded_json)
@@ -180,4 +180,4 @@ class JiraSystemConfigLoader:
     def inspect(self) -> None:
         data = self.get_project_field_keys_from_cache()
         all_keys = self.get_all_keys_from_nested_dicts(data)
-        self.print_table(self.client.issues.allowed_types or [], all_keys, data)
+        self.print_table(self.client.issues.allowed_types, all_keys, data)

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -120,7 +120,7 @@ def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
     assert set(allowed_types) == set(['Epic', 'Subtask', 'Task', 'Story', 'Bug'])
     if not (fake_jira.cache.issuetype_fields / 'createmeta_story.json').exists():
         raise FileNotFoundError('File "createmeta_story.json" should have been created')
-    assert 'Story' in (allowed_types or []), f"Testtype not in allowed_types: {allowed_types}"
+    assert 'Story' in allowed_types, f"Testtype not in allowed_types: {allowed_types}"
     with open(fake_jira.cache.issuetype_fields / "createmeta_story.json", "r") as f:
         assert f.read() == '{"issueTypes": {"name": "Testtype"}}'
 


### PR DESCRIPTION
The `JiraIssues.allowed_types` class variable is optional:

```python
class JiraIssues:
    _allowed_types: list[str] | None = None
```

We wan't it to stay nullable, in order to check for upstream issues when setting it. But we never actually want it to be `None`.

This PR forces a `ValueError` if the variable is about to be set to `None`. This allows us to remove fallbacks like this:
```python
assert 'Story' in (allowed_types or [])
```