### PR TITLE
Update cache.py

### DIFF
--- a/mantis/jira/utils/cache.py
+++ b/mantis/jira/utils/cache.py
@@ -111,9 +111,6 @@ class Cache:
     def write_createmeta(self, issuetype_name: str, issuetype_fields: list[dict[str, Any]]) -> None:
         self.write_to_issuetype_fields(f"createmeta_{issuetype_name.lower()}.json", issuetype_fields)
 
-    def write_editemeta(self, issuetype_name: str, issuetype_fields: list[dict[str, Any]]) -> None:
-        self.write_to_issuetype_fields(f"editmeta_{issuetype_name.lower()}.json", issuetype_fields)
-
     def remove(self, filename: str) -> bool:
         if not (self.root / filename).exists():
             return False


### PR DESCRIPTION
The method `write_editemeta` was previously committed without being used for anything.
It turns out, `editmeta` is unique for each individual task, so it makes little sense to treat it the same as `createmeta`.