### PR TITLE
Only write draft if not exists

### DIFF
--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -64,10 +64,12 @@ class Draft:
         )
 
     def _materialize(self) -> None:
-        self.generate_frontmatter()
-        self.generate_body()
-        with open(self.draft_path, "wb") as f:
-            frontmatter.dump(self.template, f)
+        # Only write if not exists!
+        if not self.draft_path.exists():
+            self.generate_frontmatter()
+            self.generate_body()
+            with open(self.draft_path, "wb") as f:
+                frontmatter.dump(self.template, f)
 
     def remove_draft_header(self, post: frontmatter.Post) -> frontmatter.Post:
         extra_header = f'# {self.summary}'

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -13,6 +13,7 @@ class JiraIssue:
         self.client = client
         self.data = raw_data
         # https://docs.pydantic.dev/1.10/datamodel_code_generator/
+        # Only writes if not exists.
         self.draft = Draft(self.client, self)
 
     def get(self, key: str, default: Any = None) -> Any:


### PR DESCRIPTION
Limit `_materialize` method to write drafts when they don't already exists.
This ensures that pulling issues does not overwrite local draft changes.