### PR TITLE
Get field raise for non existent key

### DIFF
--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -27,8 +27,17 @@ class JiraIssue:
         return fields
 
     def get_field(self, key: str, default: Any = None) -> Any:
-        # Note that the key can exist and the value can still be None
-        return self.fields.get(key, default) or default
+        if key in {'ignore', 'header'}:
+            return default
+        # Guarding against non-existing fields in the source data. This allows us to do only
+        # a single None-check below.
+        if key not in self.fields:
+            raise ValueError(f"key '{key}' not in self.fields (i.e. not present upstream)")
+        # Note that the key can exist and the value can still be None.
+        # We only want to fall back on the default value when the value is actually None.
+        # Boolean values would break if we relied on Truthiness.
+        value = self.fields[key]
+        return default if value is None else value
 
     def update_field(self, data: dict[str, Any]) -> None:
         key = self.data.get('key')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,22 @@ def fake_jira(
     mock_get_request,
 ):
     jira = jira_client_from_fake_cli
-    expected = {"key": "TASK-1", "fields": {"status": {"name": "resolved"}, "description": "redacted"}}
+    expected = {
+        "key": "TASK-1",
+        "fields": {
+            "summary": "redacted",
+            "ignore": True,
+            "header": "redacted",
+            "project": {"key": "redacted", "name": "redacted"},
+            "parent": "redacted",
+            "issuetype": "redacted",
+            "assignee": "redacted",
+            "key": "redacted",
+            "reporter": "redacted",
+            "status": {"name": "resolved"},
+            "description": "redacted"
+        }
+    }
     mock_get_request.return_value.json.return_value = expected
     assert str(jira.cache.root) != ".jira_cache_test"
     assert str(jira.drafts_dir) != "drafts_test"

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -16,6 +16,8 @@ def json_response(mock_get_request):
             "issuetype": {"key": "Task"},
             "assignee": {"displayName": "Bobby Goodsky"},
             "description": "redacted",
+            "project": "lolcorp",
+            "reporter": "null",
         },
     }
 
@@ -46,8 +48,8 @@ def test_jira_draft(fake_jira: JiraClient, json_response):
         "summary: Test issue",
         "issuetype:",
         "issuetype: null",
-        "project: null",
-        "reporter: null",
+        "project: lolcorp",
+        "reporter: 'null'",
         "description: redacted",
         "assignee: Bobby Goodsky",
         "status: resolved",

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -182,7 +182,7 @@ def test_jira_issues_get_does_write_to_cache(fake_jira: JiraClient):
     assert len([file for file in fake_jira.cache.issues.iterdir()]) == 1
     with open(fake_jira.cache.issues / "TASK-1.json", "r") as f:
         data = json.load(f)
-    assert data == {"fields": {"status": {"name": "resolved"}, "description": "redacted"}, "key": "TASK-1"}
+    assert data["key"] == "TASK-1"
 
 
 def test_jira_issues_get_does_retrieve_from_cache(fake_jira: JiraClient):

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -187,7 +187,24 @@ def test_jira_issues_get_does_write_to_cache(fake_jira: JiraClient):
 
 def test_jira_issues_get_does_retrieve_from_cache(fake_jira: JiraClient):
     fake_jira._no_read_cache = False
-    data = {"key": "TASK-1", "redacted": "True", "fields": {"status": {"name": "resolved"}, "description": "redacted"}}
+    data = {
+        "key": "TASK-1",
+        "redacted": "True",
+        "fields": {
+            "summary": "redacted",
+            "ignore": True,
+            "header": "redacted",
+            "project": {"key": "redacted", "name": "redacted"},
+            "parent": "redacted",
+            "issuetype": "redacted",
+            "assignee": "redacted",
+            "key": "redacted",
+            "reporter": "redacted",
+
+            "status": {"name": "resolved"},
+            "description": "redacted"
+        }
+    }
     with open(fake_jira.cache.issues / "TASK-1.json", "w") as f:
         json.dump(data, f)
     issue = fake_jira.issues.get("TASK-1")

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -19,7 +19,22 @@ def test_jira_issues_get_fake(fake_jira: JiraClient):
 
 def test_jira_issues_get_mocked(fake_jira: JiraClient, with_no_read_cache):
     assert fake_jira._no_read_cache is True
-    expected = {"key": "TASK-1", "fields": {"status": {"name": "resolved"}, "description": "redacted"}}
+    expected = {
+        "key": "TASK-1",
+        "fields": {
+            "summary": "redacted",
+            "ignore": True,
+            "header": "redacted",
+            "project": {"key": "redacted", "name": "redacted"},
+            "parent": "redacted",
+            "issuetype": "redacted",
+            "assignee": "redacted",
+            "key": "redacted",
+            "reporter": "redacted",
+            "status": {"name": "resolved"},
+            "description": "redacted"
+        }
+    }
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.ok = True


### PR DESCRIPTION
`JiraIssue.fields` is a `dict` with data coming from upstream. Any field that is not set upstream is, nonetheless, available in this payload, but its value will be `null`. Therefore, in cases where a field is not listed in the payload as a nulled value, we know that it is not available upstream.

In order to reflect this fact, in this PR we change how we handle this `None`. Where, previously, we would allow the getter to fall back to the default if a value was not set, going forward, if a key is not set in the payload, we will be raising a `ValueError`.

Raising early will ensure that we won't be attempting to model or update any fields that don't exist upstream.