### PR TITLE
Remove test test_jira_issues_get_real

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,6 @@ $ python main.py \
 ```sh
 $ pytest
 
-#Run also the tests marked as skipped (Note: This will make calls to Jira api if configured):
-$ EXECUTE_SKIPPED=1 pytest
-
 # Run tests every time a file changes (using `pytest-xdist`):
 $ pytest -f
 

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -71,23 +71,6 @@ def test_jira_issues_get_non_existent(with_no_read_cache, fake_jira: JiraClient)
             fake_jira.issues.get("PROJ-1 ")
 
 
-@pytest.mark.skipif(
-    not os.path.exists("options.toml"), reason='File "options.toml" does not exist'
-)
-@pytest.mark.skipif(
-    not os.getenv("EXECUTE_SKIPPED"), reason="This is a live test against the Jira api"
-)
-def test_jira_issues_get_real(jira_client_from_user_toml):
-    test_3 = jira_client_from_user_toml.issues.get("TEST-3")
-    assert test_3.get("key") == "TEST-3"
-    test_3_fields = test_3.get("fields", {})
-    assert test_3_fields != {}
-    test_3_status = test_3_fields.get("status", {})
-    assert test_3_status != {}
-    test_3_status_name = test_3_status.get("name", {})
-    assert test_3_status_name == "In Progress"
-
-
 @patch("mantis.jira.jira_client.requests.post")
 def test_jira_issues_create(mock_post, fake_jira: JiraClient, with_fake_allowed_types):
     mock_post.return_value.json.return_value = {}


### PR DESCRIPTION
The test `test_jira_issues_get_real` is set up to use the actual user credentials of the user's system. It is the last test of its kind in the suite and it is deactivated by default.
This PR removes it.