### PR TITLE
Fixture minimal issue payload

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,25 @@ def with_fake_allowed_types(fake_jira: JiraClient):
     fake_jira.issues._allowed_types = ["Story", "Subtask", "Epic", "Bug", "Task", "Testtype"]
 
 @pytest.fixture
+def minimal_issue_payload():
+    return {
+        "key": "TASK-1",
+        "fields": {
+            "summary": "redacted",
+            "ignore": True,
+            "header": "redacted",
+            "project": {"key": "redacted", "name": "redacted"},
+            "parent": "redacted",
+            "issuetype": {"id": "10001", "name": "Task"},
+            "assignee": "redacted",
+            "key": "redacted",
+            "reporter": "redacted",
+            "status": {"name": "resolved"},
+            "description": "redacted"
+        }
+    }
+
+@pytest.fixture
 def fake_jira(
     with_fake_cache,
     with_fake_drafts_dir,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,25 +134,10 @@ def fake_jira(
     with_fake_plugins_dir,
     jira_client_from_fake_cli,
     mock_get_request,
+    minimal_issue_payload,
 ):
     jira = jira_client_from_fake_cli
-    expected = {
-        "key": "TASK-1",
-        "fields": {
-            "summary": "redacted",
-            "ignore": True,
-            "header": "redacted",
-            "project": {"key": "redacted", "name": "redacted"},
-            "parent": "redacted",
-            "issuetype": "redacted",
-            "assignee": "redacted",
-            "key": "redacted",
-            "reporter": "redacted",
-            "status": {"name": "resolved"},
-            "description": "redacted"
-        }
-    }
-    mock_get_request.return_value.json.return_value = expected
+    mock_get_request.return_value.json.return_value = minimal_issue_payload
     assert str(jira.cache.root) != ".jira_cache_test"
     assert str(jira.drafts_dir) != "drafts_test"
     assert str(jira.plugins_dir) != "plugins_test"

--- a/tests/test_jira_cache.py
+++ b/tests/test_jira_cache.py
@@ -1,28 +1,30 @@
+import json
 import pytest
 
 from mantis.jira import JiraClient
 
 
-def test_cache_get_caches_jira_issue(fake_jira: JiraClient):
+def test_cache_get_caches_jira_issue(fake_jira: JiraClient, minimal_issue_payload):
     assert not fake_jira._no_read_cache
     assert fake_jira.cache._get(fake_jira.cache.issues, "TASK-1.json") is None
 
     with open(fake_jira.cache.root / "issues/TASK-1.json", "w") as f:
-        f.write('{"fields": {"status": {"name": "resolved"}}, "key": "TASK-1"}')
+        json.dump(minimal_issue_payload, f)
 
     decoded = fake_jira.cache._get(fake_jira.cache.issues, "TASK-1.json")
-    assert decoded == {"fields": {"status": {"name": "resolved"}}, "key": "TASK-1"}
+    assert decoded
+    assert decoded.get("key", '') == "TASK-1"
 
 
-def test_cache_get_issue_returns_none_when_no_read_cache_is_set(fake_jira: JiraClient):
+def test_cache_get_issue_returns_none_when_no_read_cache_is_set(fake_jira: JiraClient, minimal_issue_payload):
     # Make sure nothing is cached
     assert not fake_jira._no_read_cache
     assert fake_jira.cache.get_issue("TASK-1") is None
 
     # cache something
-    with open(fake_jira.cache.root / "issues/task-1.json", "w") as f:
-        f.write('{"fields": {"status": {"name": "resolved"}}, "key": "task-1"}')
-    something = fake_jira.cache.get_issue("task-1")
+    with open(fake_jira.cache.root / "issues/TASK-1.json", "w") as f:
+        json.dump(minimal_issue_payload, f)
+    something = fake_jira.cache.get_issue("TASK-1")
     assert something is not None
 
     # Deactivate the cache and make sure nothing is retrieved
@@ -32,10 +34,10 @@ def test_cache_get_issue_returns_none_when_no_read_cache_is_set(fake_jira: JiraC
         assert nothing_2 is None
 
 
-def test_cache_remove_does_removals(fake_jira: JiraClient):
+def test_cache_remove_does_removals(fake_jira: JiraClient, minimal_issue_payload):
     # cache something
-    with open(fake_jira.cache.root / "issues/task-1.json", "w") as f:
-        f.write('{"fields": {"status": {"name": "resolved"}}, "key": "task-1"}')
+    with open(fake_jira.cache.root / "issues/TASK-1.json", "w") as f:
+        json.dump(minimal_issue_payload, f)
     something_1 = fake_jira.cache.get_issue("task-1")
     assert something_1 is not None
 
@@ -46,10 +48,10 @@ def test_cache_remove_does_removals(fake_jira: JiraClient):
     assert nothing_1 is None
 
 
-def test_cache_remove_issue_does_removals(fake_jira: JiraClient):
+def test_cache_remove_issue_does_removals(fake_jira: JiraClient, minimal_issue_payload):
     # cache something
-    with open(fake_jira.cache.root / "issues/task-1.json", "w") as f:
-        f.write('{"fields": {"status": {"name": "resolved"}}, "key": "task-1"}')
+    with open(fake_jira.cache.root / "issues/TASK-1.json", "w") as f:
+        json.dump(minimal_issue_payload, f)
     something_2 = fake_jira.cache.get_issue("task-1")
     assert something_2 is not None
 

--- a/tests/test_jira_cache.py
+++ b/tests/test_jira_cache.py
@@ -38,13 +38,13 @@ def test_cache_remove_does_removals(fake_jira: JiraClient, minimal_issue_payload
     # cache something
     with open(fake_jira.cache.root / "issues/TASK-1.json", "w") as f:
         json.dump(minimal_issue_payload, f)
-    something_1 = fake_jira.cache.get_issue("task-1")
+    something_1 = fake_jira.cache.get_issue("TASK-1")
     assert something_1 is not None
 
     # remove with cache.remove
-    assert fake_jira.cache.remove("issues/task-1.json")
-    assert not fake_jira.cache.remove("issues/task-1.json")
-    nothing_1 = fake_jira.cache.get_issue("task-1")
+    assert fake_jira.cache.remove("issues/TASK-1.json")
+    assert not fake_jira.cache.remove("issues/TASK-1.json")
+    nothing_1 = fake_jira.cache.get_issue("TASK-1")
     assert nothing_1 is None
 
 
@@ -52,12 +52,12 @@ def test_cache_remove_issue_does_removals(fake_jira: JiraClient, minimal_issue_p
     # cache something
     with open(fake_jira.cache.root / "issues/TASK-1.json", "w") as f:
         json.dump(minimal_issue_payload, f)
-    something_2 = fake_jira.cache.get_issue("task-1")
+    something_2 = fake_jira.cache.get_issue("TASK-1")
     assert something_2 is not None
 
     # remove with cache.remove_issue
-    fake_jira.cache.remove_issue("task-1")
-    nothing_2 = fake_jira.cache.get_issue("task-1")
+    fake_jira.cache.remove_issue("TASK-1")
+    nothing_2 = fake_jira.cache.get_issue("TASK-1")
     assert nothing_2 is None
 
 

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -23,7 +23,7 @@ def test_jira_draft(fake_jira: JiraClient, minimal_issue_payload):
     with open(fake_jira.drafts_dir / "TASK-1.md", "r") as f:
         content = f.read()
     assert "assignee: Bobby Goodsky" in content
-    assert "Bobby Goodsky" == fake_jira.issues.get('Task-1').draft.issue.get_field("assignee", {}).get(
+    assert "Bobby Goodsky" == fake_jira.issues.get('TASK-1').draft.issue.get_field("assignee", {}).get(
         "displayName", ""
     )
     expectations = (

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -5,56 +5,42 @@ from mantis.jira import JiraClient
 from mantis.jira.jira_issues import JiraIssue
 
 
-@pytest.fixture
-def json_response(mock_get_request):
-    mock_get_request.return_value.json.return_value = {
-        "key": "TASK-1",
-        "fields": {
-            "status": {"name": "resolved"},
-            "summary": "Test issue",
-            "parent": "TASK-0",
-            "issuetype": {"key": "Task"},
-            "assignee": {"displayName": "Bobby Goodsky"},
-            "description": "redacted",
-            "project": "lolcorp",
-            "reporter": "null",
-        },
-    }
-
-
-def test_jira_draft(fake_jira: JiraClient, json_response):
+def test_jira_draft(fake_jira: JiraClient, minimal_issue_payload):
+    minimal_issue_payload['fields']['assignee'] = {"displayName": "Bobby Goodsky"}
     assert str(fake_jira.cache.root) != ".jira_cache_test"
     assert str(fake_jira.drafts_dir) != "drafts_test"
     # assert str(fake_jira.cache.root) != str(fake_jira.drafts_dir)
+    
     assert len(list(fake_jira.drafts_dir.iterdir())) == 0
-
-    # assert list(fake_jira.drafts_dir.iterdir())[0] == ""
-    task_1 = fake_jira.issues.get("TASK-44")
-    assert type(task_1) == JiraIssue
-    draft = Draft(fake_jira, task_1)
+    task_1 = fake_jira.issues.get("TASK-1")
     assert len([*fake_jira.drafts_dir.iterdir()]) == 1
+    assert isinstance(task_1, JiraIssue)
+
+    minimal_issue_payload['key'] = "TASK-2"
+    task_2 = fake_jira.issues.get("TASK-2")
+    assert len([*fake_jira.drafts_dir.iterdir()]) == 2
 
     with open(fake_jira.drafts_dir / "TASK-1.md", "r") as f:
         content = f.read()
     assert "assignee: Bobby Goodsky" in content
-    assert "Bobby Goodsky" == draft.issue.get_field("assignee", {}).get(
+    assert "Bobby Goodsky" == fake_jira.issues.get('Task-1').draft.issue.get_field("assignee", {}).get(
         "displayName", ""
     )
     expectations = (
         "---",
-        "header: '[TASK-1] Test issue'",
+        "header: '[TASK-1] redacted'",
         "ignore: true",
-        "parent: TASK-0",
-        "summary: Test issue",
+        "parent: redacted",
+        "summary: redacted",
         "issuetype:",
-        "issuetype: null",
-        "project: lolcorp",
-        "reporter: 'null'",
+        "issuetype: Task",
+        "project: redacted",
+        "reporter: redacted",
         "description: redacted",
         "assignee: Bobby Goodsky",
         "status: resolved",
         "---",
-        "# Test issue",
+        "# redacted",
         "",
         "redacted",
     )


### PR DESCRIPTION
Add a new fixture `minimal_issue_payload` to `Pytest` suite.
This replaces a number of custom return payloads in individual tests.