### PR TITLE
Move all request handling under JiraClient

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -128,9 +128,10 @@ class JiraClient:
         issue_data: dict[str, dict] = response.json()
         return issue_data
 
-
-    def post_issue(self, data: dict) -> requests.Response:
-        return self._post("issue", data=data)
+    def post_issue(self, data: dict) -> dict:
+        response = self._post("issue", data=data)
+        response.raise_for_status()
+        return response.json()
 
     def warmup(self) -> None:
         self.cache.invalidate()

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -137,7 +137,7 @@ class JiraClient:
 
     def warmup(self) -> None:
         self.cache.invalidate()
-        self.system_config_loader.update_projects_cache()
+        self.system_config_loader.get_projects(force_skip_cache = True)
         assert not self.cache.get_issuetypes_from_system_cache()
         self.system_config_loader.update_issuetypes_cache()
         self.system_config_loader.get_issuetypes()
@@ -145,10 +145,17 @@ class JiraClient:
         resp = self.system_config_loader.update_project_field_keys()
         pprint(resp)
 
-    def get_projects(self) -> None:
-        projects = self.cache.get_projects_from_system_cache()
-        if not projects:
-            raise ValueError('Projects not initialized')
+    def get_projects(self) -> list[dict[str, Any]]:
+        url = 'project'
+        response = self._get(url)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print(e.response.reason)
+            print(e.response.content)
+            exit()
+        payload: list[dict[str, Any]] = response.json()
+        return payload
 
     def get_current_user(self) -> dict[str, str]:
         response = self._get("myself")

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -98,6 +98,21 @@ class JiraClient:
         url = f"{self.api_url}/{uri}"
         return requests.put(url, json=data, **self.requests_kwargs)  # type: ignore
 
+    def get_issuetypes(self) -> dict[str, Any]:
+        url = f'issue/createmeta/{self.project_name}/issuetypes'
+        response = self._get(url)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print(e.response.reason)
+            print(e.response.content)
+            exit()
+        issuetypes: dict[str, Any] = response.json()
+        assert isinstance(issuetypes, dict), f'issuetypes is not a dict: {issuetypes}'
+        assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got: {issuetypes}"
+        assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
+        return issuetypes
+
     def get_createmeta(self, project_name: str, issuetype_id: str) -> requests.Response:
         url = (
             "issue/createmeta"

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -113,14 +113,11 @@ class JiraClient:
         assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
         return issuetypes
 
-    def get_createmeta(self, project_name: str, issuetype_id: str) -> requests.Response:
-        url = (
-            "issue/createmeta"
-            f"/{project_name}"
-            "/issuetypes/"
-            f"{issuetype_id}"
-        )
-        return self._get(url)
+    def get_createmeta(self, project_name: str, issuetype_id: str) -> list[dict[str, Any]]:
+        url = f"issue/createmeta/{project_name}/issuetypes/{issuetype_id}"
+        response = self._get(url)
+        response.raise_for_status()
+        return response.json()
 
     def get_issue(self, key: str) -> dict[str, dict]:
         response = self._get(f"issue/{key}")

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -139,7 +139,7 @@ class JiraClient:
         self.cache.invalidate()
         self.system_config_loader.get_projects(force_skip_cache = True)
         assert not self.cache.get_issuetypes_from_system_cache()
-        self.system_config_loader.update_issuetypes_cache()
+        self.system_config_loader.get_issuetypes(force_skip_cache = True)
         self.system_config_loader.get_issuetypes()
         assert self.cache.get_issuetypes_from_system_cache()
         resp = self.system_config_loader.update_project_field_keys()

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 from typing import TYPE_CHECKING, Any
 
 from requests.models import HTTPError
@@ -95,9 +97,5 @@ class JiraIssues:
         print(f"Create issue ({issuetype}): {title}")
 
         response = self.client.post_issue(data)
-        from pprint import pprint
-
-        pprint(response.json())
-        response.raise_for_status()
-        response_data: dict = response.json()
-        return response_data
+        pprint(response)
+        return response

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -79,8 +79,8 @@ class JiraIssues:
                 raise ValueError('Loading allowed_types failed.')
         return self._allowed_types
 
-    def get(self, key: str) -> JiraIssue:
-        if not self.client._no_read_cache:
+    def get(self, key: str, force_skip_cache: bool = False) -> JiraIssue:
+        if not self.client._no_read_cache or force_skip_cache:
             issue_data_from_cache = self.client.cache.get_issue(key)
             if issue_data_from_cache:
                 return JiraIssue(self.client, issue_data_from_cache)

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -2,8 +2,6 @@ from pprint import pprint
 
 from typing import TYPE_CHECKING, Any
 
-from requests.models import HTTPError
-
 from mantis.drafts import Draft
 
 if TYPE_CHECKING:

--- a/mantis/jira/utils/cache.py
+++ b/mantis/jira/utils/cache.py
@@ -66,7 +66,11 @@ class Cache:
     def get_projects_from_system_cache(self) -> dict[str, Any] | list[dict[str, Any]] | None:
         if self.client._no_read_cache:
             raise LookupError('Attempted to access cache when _no_read_cache is set')
-        return self.get_from_system_cache(f"projects.json")
+        projects = self.get_from_system_cache(f"projects.json")
+        if not projects:
+            return None
+        assert isinstance(projects, list), f'{projects} should be of type list. Got: {type(projects)}: {projects}'
+        return projects
 
     def get_issuetypes_from_system_cache(self) -> dict[str, Any] | None:
         if self.client._no_read_cache:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -1,5 +1,4 @@
 import json
-import requests
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Generator, KeysView, Optional

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -154,20 +154,7 @@ class JiraSystemConfigLoader:
         return self.update_projects_cache()
 
     def update_issuetypes_cache(self) -> dict[str, Any]:
-        url = f'issue/createmeta/{self.client.project_name}/issuetypes'
-        response = self.client._get(url)
-        try:
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            print(e.response.reason)
-            print(e.response.content)
-            exit()
-
-        issuetypes: dict[str, Any] = response.json()
-        assert isinstance(issuetypes, dict), f'issuetypes is not a dict: {issuetypes}'
-        assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got: {issuetypes}"
-        assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
-
+        issuetypes = self.client.get_issuetypes()
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -175,9 +175,7 @@ class JiraSystemConfigLoader:
             assert 'id' in issuetype.keys()
             issuetype_name = issuetype['name']
             issuetype_id = issuetype['id']
-            response = self.client.get_createmeta(self.client.project_name, issuetype_id)
-            response.raise_for_status()
-            data: list[dict[str, Any]] = response.json()
+            data: list[dict[str, Any]] = self.client.get_createmeta(self.client.project_name, issuetype_id)
             self.cache.write_createmeta(issuetype_name, data)
         return self.client.issues.load_allowed_types()
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -141,17 +141,14 @@ class JiraSystemConfigLoader:
         self.cache.write_to_system_cache("projects.json", json.dumps(projects))
         return projects
 
-    def update_issuetypes_cache(self) -> dict[str, Any]:
-        issuetypes = self.client.get_issuetypes()
-        self.cache.write_issuetypes_to_system_cache(issuetypes)
-        return issuetypes
-
-    def get_issuetypes(self) -> dict[str, Any]:
-        if not self.client._no_read_cache:
+    def get_issuetypes(self, force_skip_cache: bool = False) -> dict[str, Any]:
+        if not self.client._no_read_cache or force_skip_cache:
             from_cache = self.cache.get_issuetypes_from_system_cache()
             if from_cache:
                 return from_cache
-        return self.update_issuetypes_cache()
+        issuetypes = self.client.get_issuetypes()
+        self.cache.write_issuetypes_to_system_cache(issuetypes)
+        return issuetypes
 
     def get_issuetypes_for_project(self) -> dict[str, Any]:
         data = self.get_issuetypes()

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -153,13 +153,9 @@ class JiraSystemConfigLoader:
     def get_issuetypes_for_project(self) -> dict[str, Any]:
         data = self.get_issuetypes()
         self.cache.write_issuetypes_to_system_cache(data)
-        try:
-            assert len(data)
-        except AssertionError as e:
+        if len(data) == 0:
             raise ValueError(
-                'List of issuetypes has length of zero. '
-                'Something is probably very wrong.'
-            ) from e
+                'List of issuetypes has length of zero. Something is probably very wrong.')
         return data
 
     def update_project_field_keys(self) -> list[str]:

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -71,7 +71,7 @@ def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
     assert fake_jira._project_id == None
 
     # Fetch and cache projects data (without updating the object)
-    got_projects = config_loader.update_projects_cache()
+    got_projects = config_loader.get_projects(force_skip_cache = True)
     assert isinstance(got_projects, list)
     assert len(got_projects) == 2
     assert {_['id'] for _ in got_projects} == {'10000', '10001'}

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -18,7 +18,7 @@ def test_config_loader_update_issuetypes_writes_to_cache(
     assert len(list(fake_jira.cache.system.iterdir())) == 1, (
         f"Not empty: {fake_jira.cache.system}")
 
-    config_loader.update_issuetypes_cache()
+    config_loader.get_issuetypes(force_skip_cache = True) 
     assert len(list(fake_jira.cache.system.iterdir())) == 2, (
         f"Not empty: {fake_jira.cache.system}")
 


### PR DESCRIPTION
Simplify the call stack by moving all Jira API handling under the `JiraClient`.

This also eliminates the need for dedicated methods for `update_projects_cache` and `update_issuetypes_cache`. These are each folded into `get_projects` and `get_issuetypes` respectively. Both now take the parameter `force_skip_cache = True` to retain the original functionality.