### PR TITLE
Merge and rename methods

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
             jira._no_read_cache = False
     elif jira_options.action == 'get-project-keys':
         print ('Fetching from Jira...')
-        resp = jira.system_config_loader.update_createmeta()
+        resp = jira.system_config_loader.fetch_and_update_all_createmeta()
         print('Dumped field values for:')
         pprint(resp)
     elif jira_options.action == 'inspect':

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
             jira._no_read_cache = False
     elif jira_options.action == 'get-project-keys':
         print ('Fetching from Jira...')
-        resp = jira.system_config_loader.update_project_field_keys()
+        resp = jira.system_config_loader.update_createmeta()
         print('Dumped field values for:')
         pprint(resp)
     elif jira_options.action == 'inspect':

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -139,7 +139,7 @@ class JiraClient:
         assert not self.cache.get_issuetypes_from_system_cache()
         self.system_config_loader.get_issuetypes(force_skip_cache = True)
         assert self.cache.get_issuetypes_from_system_cache()
-        resp = self.system_config_loader.update_createmeta()
+        resp = self.system_config_loader.fetch_and_update_all_createmeta()
         pprint(resp)
 
     def get_projects(self) -> list[dict[str, Any]]:

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -124,7 +124,10 @@ class JiraClient:
         url = f"issue/createmeta/{self.project_name}/issuetypes/{issuetype_id}"
         response = self._get(url)
         response.raise_for_status()
-        return response.json()
+        data = response.json()
+        assert isinstance(data, dict)
+        assert 'fields' in data.keys(), f'Key "fields" not in data.keys(). Got: {data.keys()} ... {data}'
+        return data
 
     def get_issue(self, key: str) -> dict[str, dict]:
         response = self._get(f"issue/{key}")

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -138,9 +138,8 @@ class JiraClient:
         self.system_config_loader.get_projects(force_skip_cache = True)
         assert not self.cache.get_issuetypes_from_system_cache()
         self.system_config_loader.get_issuetypes(force_skip_cache = True)
-        self.system_config_loader.get_issuetypes()
         assert self.cache.get_issuetypes_from_system_cache()
-        resp = self.system_config_loader.update_project_field_keys()
+        resp = self.system_config_loader.update_createmeta()
         pprint(resp)
 
     def get_projects(self) -> list[dict[str, Any]]:

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -107,7 +107,7 @@ class JiraClient:
             print(e.response.reason)
             print(e.response.content)
             exit()
-        issuetypes: dict[str, Any] = response.json()
+        issuetypes: dict[str, list[dict[str, Any]]] = response.json()
         assert isinstance(issuetypes, dict), f'issuetypes is not a dict: {issuetypes}'
         assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got: {issuetypes}"
         assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -98,7 +98,7 @@ class JiraClient:
         url = f"{self.api_url}/{uri}"
         return requests.put(url, json=data, **self.requests_kwargs)  # type: ignore
 
-    def get_issuetypes(self) -> dict[str, Any]:
+    def get_issuetypes(self) -> dict[str, list[dict[str, Any]]]:
         url = f'issue/createmeta/{self.project_name}/issuetypes'
         response = self._get(url)
         try:

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -113,8 +113,9 @@ class JiraClient:
         assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
         return issuetypes
 
-    def get_createmeta(self, project_name: str, issuetype_id: str) -> list[dict[str, Any]]:
-        url = f"issue/createmeta/{project_name}/issuetypes/{issuetype_id}"
+    def get_createmeta(self, issuetype_id: str) -> dict[str, list[dict[str, Any]]]:
+        """Createmeta is a list of fields"""
+        url = f"issue/createmeta/{self.project_name}/issuetypes/{issuetype_id}"
         response = self._get(url)
         response.raise_for_status()
         return response.json()

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -111,6 +111,12 @@ class JiraClient:
         assert isinstance(issuetypes, dict), f'issuetypes is not a dict: {issuetypes}'
         assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got: {issuetypes}"
         assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
+        li = issuetypes['issueTypes']
+        assert isinstance(li, list), f"issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
+        for x in li:
+            for y,z in x.items():
+                assert isinstance(y, str)
+                assert z is not None, f"key {y} is None"
         return issuetypes
 
     def get_createmeta(self, issuetype_id: str) -> dict[str, list[dict[str, Any]]]:

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -58,7 +58,7 @@ class JiraIssues:
 
     def load_allowed_types(self) -> list[str]:
         issuetypes = (
-            self.client.system_config_loader.get_issuetypes_for_project()
+            self.client.system_config_loader.get_issuetypes()
         )
         if not issuetypes:
             raise ValueError('No values retrieved for issuetypes')

--- a/mantis/jira/utils/cache.py
+++ b/mantis/jira/utils/cache.py
@@ -116,7 +116,7 @@ class Cache:
     def write_issuetypes_to_system_cache(self, issuetypes: dict[str, Any]) -> None:
         self.write_to_system_cache("issuetypes.json", json.dumps(issuetypes))
 
-    def write_createmeta(self, issuetype_name: str, createmeta: list[dict[str, Any]]) -> None:
+    def write_createmeta(self, issuetype_name: str, createmeta: dict[str, int | dict]) -> None:
         filename = f"createmeta_{issuetype_name.lower()}.json"
         self._write(self.createmeta, filename, json.dumps(createmeta))
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -147,19 +147,14 @@ class JiraSystemConfigLoader:
             if from_cache:
                 return from_cache
         issuetypes = self.client.get_issuetypes()
+        if len(issuetypes) == 0:
+            raise ValueError(
+                'List of issuetypes has length of zero. Something is probably very wrong.')
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 
-    def get_issuetypes_for_project(self) -> dict[str, Any]:
-        data = self.get_issuetypes()
-        self.cache.write_issuetypes_to_system_cache(data)
-        if len(data) == 0:
-            raise ValueError(
-                'List of issuetypes has length of zero. Something is probably very wrong.')
-        return data
-
     def update_project_field_keys(self) -> list[str]:
-        issuetypes: dict[str, Any] = self.get_issuetypes_for_project()
+        issuetypes: dict[str, Any] = self.get_issuetypes()
 
         assert isinstance(issuetypes, dict)
         assert 'issueTypes' in issuetypes, f'issueTypes has no issueTypes {issuetypes}'

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -166,11 +166,21 @@ class JiraSystemConfigLoader:
         return self.client.issues.load_allowed_types()
 
     def _update_single_createmeta(self, issuetype: dict[str, Any]) -> dict[str, Any]:
+        assert 'name' in issuetype.keys()
+        assert 'id' in issuetype.keys()
         issuetype_name: str = issuetype['name']
         issuetype_id: str = issuetype['id']
+        assert isinstance(issuetype_name, str)
+        assert isinstance(issuetype_id, str)
         data: dict[str, Any] = self.client.get_createmeta(issuetype_id)
+        assert isinstance(data, dict)
+        # assert set(['x']) == set(data), f'{data}'
+        # assert set(data[0].keys()) == set()
         self.cache.write_createmeta(issuetype_name, data)
         return data        
+        fields = CreatemetaModelFactory(self.client, issuetype_name)#, f'issuetype_name: {issuetype_name}'
+        return fields.make(data)
+
 
     def compile_plugins(self) -> None:
         for input_file in self.cache.iter_dir("createmeta"):

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -141,7 +141,7 @@ class JiraSystemConfigLoader:
         self.cache.write_to_system_cache("projects.json", json.dumps(projects))
         return projects
 
-    def get_issuetypes(self, force_skip_cache: bool = False) -> dict[str, Any]:
+    def get_issuetypes(self, force_skip_cache: bool = False) -> dict[str, list[dict[str, Any]]]:
         if not self.client._no_read_cache or force_skip_cache:
             from_cache = self.cache.get_issuetypes_from_system_cache()
             if from_cache:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -153,7 +153,7 @@ class JiraSystemConfigLoader:
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 
-    def update_project_field_keys(self) -> list[str]:
+    def update_createmeta(self) -> list[str]:
         issuetypes: dict[str, Any] = self.get_issuetypes()
 
         assert isinstance(issuetypes, dict)

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -153,7 +153,7 @@ class JiraSystemConfigLoader:
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 
-    def update_createmeta(self) -> list[str]:
+    def fetch_and_update_all_createmeta(self) -> list[str]:
         issuetypes: dict[str, Any] = self.get_issuetypes()
 
         assert isinstance(issuetypes, dict)

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -151,6 +151,7 @@ class JiraSystemConfigLoader:
         if len(issuetypes.keys()) == 0:
             raise ValueError(
                 'List of issuetypes has length of zero. Something is probably very wrong.')
+        assert 'issueTypes' in issuetypes, f'issueTypes has no issueTypes {issuetypes}'
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -147,7 +147,8 @@ class JiraSystemConfigLoader:
             if from_cache:
                 return from_cache
         issuetypes = self.client.get_issuetypes()
-        if len(issuetypes) == 0:
+        assert isinstance(issuetypes, dict)
+        if len(issuetypes.keys()) == 0:
             raise ValueError(
                 'List of issuetypes has length of zero. Something is probably very wrong.')
         self.cache.write_issuetypes_to_system_cache(issuetypes)

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -34,6 +34,7 @@ class CreatemetaModelFactory:
         self.createmeta = self.jira.cache.get_createmeta_from_cache(self.type_name)
         if not self.createmeta:
             raise CacheMissException(f"{self.type_name}")
+        assert "fields" in self.createmeta.keys(), f"'fields' not in createmeta.keys: {self.createmeta.keys()}"
         self.createmeta_fields: list[dict[str, Any]] = self.createmeta["fields"]
         self.create_model()
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -159,7 +159,7 @@ class JiraSystemConfigLoader:
         nested_issuetypes = issuetypes['issueTypes']
 
         for issuetype in nested_issuetypes:
-            data: list[dict[str, Any]] = self.client.get_createmeta(self.client.project_name, issuetype_id)
+            data = self._update_single_createmeta(issuetype)
         return self.client.issues.load_allowed_types()
 
     def _update_single_createmeta(self, issuetype: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -116,7 +116,7 @@ def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
 
     if (fake_jira.cache.createmeta / 'createmeta_story.json').exists():
         raise FileExistsError('File "createmeta_story.json" should not exist yet')
-    allowed_types = config_loader.update_project_field_keys()
+    allowed_types = config_loader.update_createmeta()
     assert set(allowed_types) == set(['Epic', 'Subtask', 'Task', 'Story', 'Bug'])
     if not (fake_jira.cache.createmeta / 'createmeta_story.json').exists():
         raise FileNotFoundError('File "createmeta_story.json" should have been created')

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -116,7 +116,7 @@ def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
 
     if (fake_jira.cache.createmeta / 'createmeta_story.json').exists():
         raise FileExistsError('File "createmeta_story.json" should not exist yet')
-    allowed_types = config_loader.update_createmeta()
+    allowed_types = config_loader.fetch_and_update_all_createmeta()
     assert set(allowed_types) == set(['Epic', 'Subtask', 'Task', 'Story', 'Bug'])
     if not (fake_jira.cache.createmeta / 'createmeta_story.json').exists():
         raise FileNotFoundError('File "createmeta_story.json" should have been created')

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -112,7 +112,7 @@ def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
     if not (fake_jira.cache.system / 'issuetypes.json').exists():
         raise FileNotFoundError('File "issuetypes.json" should have been created')
 
-    mock_get.return_value.json.return_value = {'issueTypes': {"name": "Testtype"}}
+    mock_get.return_value.json.return_value = {'fields': []}
 
     if (fake_jira.cache.createmeta / 'createmeta_story.json').exists():
         raise FileExistsError('File "createmeta_story.json" should not exist yet')
@@ -122,7 +122,7 @@ def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
         raise FileNotFoundError('File "createmeta_story.json" should have been created')
     assert 'Story' in allowed_types, f"Testtype not in allowed_types: {allowed_types}"
     with open(fake_jira.cache.createmeta / "createmeta_story.json", "r") as f:
-        assert f.read() == '{"issueTypes": {"name": "Testtype"}}'
+        assert f.read() == '{"fields": []}'
 
 
 @patch("mantis.jira.jira_client.requests.get")

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -131,7 +131,7 @@ def test_jira_issues_cached_issuetypes_parses_allowed_types(fake_jira: JiraClien
             {"id": '2', "name": "Task", 'scope': {'project': {'id': '10000'}}}
         ]
     }
-    fake_jira.system_config_loader.get_issuetypes_for_project = (
+    fake_jira.system_config_loader.get_issuetypes = (
         lambda *args, **kwargs: cached_issuetypes
     )
     fake_jira.issues = JiraIssues(fake_jira)


### PR DESCRIPTION
Merge `get_issuetypes_for_project` and `get_issuetypes`

Rename `update_project_field_keys` to `fetch_and_update_all_createmeta` and split out `_update_single_createmeta`.