### PR TITLE
Subclass MetaModelFactory

### DIFF
--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -17,13 +17,13 @@ if TYPE_CHECKING:
 class CreatemetaModelFactory:
     # Fields created by Jira that are present in the issue json, but cannot
     # be set by the user.
-    ignored_non_meta_field = (
+    ignored_non_meta_field = {
         "statuscategorychangedate",
         "components",
         "timespent",
         # 'environment' is a legacy field (and only relevant in editmeta)
         # "environment"
-    )
+    }
 
     def __init__(self, jira: "JiraClient", type_name: str):
         self.jira = jira

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class MetaModelFactory:
     # Fields created by Jira that are present in the issue json, but cannot
     # be set by the user. These are overwritten in sub-classes.
-    ignored_non_meta_field = {}
+    ignored_non_meta_field: set[str] = set()
 
     def __init__(self, metadata: dict[str, Any]):
         self.out_fields: dict[str, Any] = {}

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -16,14 +16,8 @@ if TYPE_CHECKING:
 
 class MetaModelFactory:
     # Fields created by Jira that are present in the issue json, but cannot
-    # be set by the user.
-    ignored_non_meta_field = {
-        "statuscategorychangedate",
-        "components",
-        "timespent",
-        # 'environment' is a legacy field (and only relevant in editmeta)
-        # "environment"
-    }
+    # be set by the user. These are overwritten in sub-classes.
+    ignored_non_meta_field = {}
 
     def __init__(self, metadata: dict[str, Any]):
         self.out_fields: dict[str, Any] = {}


### PR DESCRIPTION
In order to support `createmeta` as well as `editmeta`, we rename `CreateMetaModelFactory` to `MetaModelFactory`, and create two new sub-classes: `CreateMetaModelFactory` and `EditMetaModelFactory`, that will both inherit from it.