### PR TITLE
Create JiraIssues.createmeta method

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -119,6 +119,14 @@ class JiraClient:
                 assert z is not None, f"key {y} is None"
         return issuetypes
 
+    def issuetype_name_to_id(self, issuetype_name: str) -> str:
+        nested_issuetypes = self.system_config_loader.get_issuetypes().get('issueTypes', [{}])
+        some_issuetypes = [t for t in nested_issuetypes if t.get('name', '').lower() == issuetype_name.lower()]
+        assert len(some_issuetypes) > 0, f"No issuetypes found named {issuetype_name}"
+        one_issuetype = some_issuetypes[0]
+        issuetype_id = one_issuetype['id']
+        return issuetype_id
+
     def get_createmeta(self, issuetype_id: str) -> dict[str, list[dict[str, Any]]]:
         """Createmeta is a list of fields"""
         url = f"issue/createmeta/{self.project_name}/issuetypes/{issuetype_id}"

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -28,6 +28,12 @@ class JiraIssue:
         return key
 
     @property
+    def issuetype(self) -> str:
+        if not 'issuetype' in self.fields.keys():
+            raise ValueError(f'Field "issuetype" not in JiraIssue.data. Available keys: {list(self.data.keys())}')
+        return self.data['fields']['issuetype']['name']
+
+    @property
     def createmeta_data(self) -> dict[str, list[dict[str, Any]]]:
         self._createmeta_data = self.client.system_config_loader.get_createmeta(self.issuetype)
         return self._createmeta_data

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -3,6 +3,7 @@ from pprint import pprint
 from typing import TYPE_CHECKING, Any
 
 from mantis.drafts import Draft
+from mantis.jira.utils.jira_system_config_loader import CreatemetaModelFactory
 
 if TYPE_CHECKING:
     from .jira_client import JiraClient
@@ -25,6 +26,16 @@ class JiraIssue:
         if not key:
             raise ValueError('No key')
         return key
+
+    @property
+    def createmeta_data(self) -> dict[str, list[dict[str, Any]]]:
+        self._createmeta_data = self.client.system_config_loader.get_createmeta(self.issuetype)
+        return self._createmeta_data
+
+    @property
+    def createmeta(self) -> CreatemetaModelFactory:
+        self.createmeta_object = CreatemetaModelFactory(self.createmeta_data)
+        return self.createmeta_object
 
     @property
     def editmeta(self) -> dict[str, Any]:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -196,6 +196,21 @@ class JiraSystemConfigLoader:
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 
+    def get_createmeta(self, issuetype_name: str, force_skip_cache: bool = False) -> dict[str, list[dict[str, Any]]]:
+        if not self.client._no_read_cache or force_skip_cache:
+            from_cache = self.cache.get_createmeta_from_cache(issuetype_name)
+            if from_cache:
+                return from_cache
+        issuetype_id = self.client.issuetype_name_to_id(issuetype_name)
+        issuetypes = self.client.get_createmeta(issuetype_id)
+        assert isinstance(issuetypes, dict)
+        if len(issuetypes.keys()) == 0:
+            raise ValueError(
+                'List of issuetypes has length of zero. Something is probably very wrong.')
+        assert 'issueTypes' in issuetypes, f'issueTypes has no issueTypes {issuetypes}'
+        self.cache.write_issuetypes_to_system_cache(issuetypes)
+        return issuetypes
+
     def fetch_and_update_all_createmeta(self) -> list[str]:
         """Updates all createmate from upstream, returns updated list of allowed types"""
         issuetypes: dict[str, list[dict[str, Any]]] = self.get_issuetypes(force_skip_cache = False)


### PR DESCRIPTION
In order to access fully instantiated `CreatemetaModelFactory`, we create a `createmeta` method directly on the `JiraIssue` object.