### PR TITLE
Issue.get_field to not raise ValueError

### DIFF
--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -60,8 +60,6 @@ class JiraIssue:
         If a key is not present in the cached data, a ValueError will be raised.
         If a key is present, put its value is null, the default parameter will
         be returned."""
-        if key in {'ignore', 'header'}:
-            return default
         # Guarding against non-existing fields in the source data. This allows us to do only
         # a single None-check below.
         if key not in self.fields:

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -55,6 +55,11 @@ class JiraIssue:
         return fields
 
     def get_field(self, key: str, default: Any = None) -> Any:
+        """Gets the target field of a cached issue.
+        
+        If a key is not present in the cached data, a ValueError will be raised.
+        If a key is present, put its value is null, the default parameter will
+        be returned."""
         if key in {'ignore', 'header'}:
             return default
         # Guarding against non-existing fields in the source data. This allows us to do only

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -65,7 +65,8 @@ class JiraIssue:
         # Guarding against non-existing fields in the source data. This allows us to do only
         # a single None-check below.
         if key not in self.fields:
-            raise ValueError(f"key '{key}' not in self.fields (i.e. not present upstream)")
+            print(f"key '{key}' not in self.fields (i.e. not present upstream)")
+            return default
         # Note that the key can exist and the value can still be None.
         # We only want to fall back on the default value when the value is actually None.
         # Boolean values would break if we relied on Truthiness.

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -57,18 +57,18 @@ class JiraIssue:
     def get_field(self, key: str, default: Any = None) -> Any:
         """Gets the target field of a cached issue.
         
-        If a key is not present in the cached data, a ValueError will be raised.
-        If a key is present, put its value is null, the default parameter will
-        be returned."""
-        # Guarding against non-existing fields in the source data. This allows us to do only
-        # a single None-check below.
+        If a key is not present in the cached data, this means that the field is not set in
+        upstream Jira. The field might exist or it might not. In both cases we return the
+        default value (or None if not specified).
+        Whether a field is available in Jira or not can be found by looking at the createmeta
+        or editmeta endpoints.
+        """
         if key not in self.fields:
             print(f"key '{key}' not in self.fields (i.e. not present upstream)")
             return default
-        # Note that the key can exist and the value can still be None.
-        # We only want to fall back on the default value when the value is actually None.
-        # Boolean values would break if we relied on Truthiness.
+        # Field is sure to exist, but it might still have value None.
         value = self.fields[key]
+        # Boolean values would break if we relied on Truthiness. Using None identity check instead.
         return default if value is None else value
 
     def update_field(self, data: dict[str, Any]) -> None:


### PR DESCRIPTION
Instead of raising `ValueError` when a field does not exist in the (cached) upstream issue data, we instead return `None` or the `default` value. This means we will need to do `None`-checks elsewhere to avoid preparing bad updates. However, this is what the `createmeta` and `editmeta` endpoints are for, so we should not rely on the issue data to decide which fields exist and which ones don't.