### PR TITLE
Use mark to skip slow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ $ pytest
 # Run tests every time a file changes (using `pytest-xdist`):
 $ pytest -f
 
+# Skip slow tests:
+$ pytest -m "not slow"
+
 # Show test coverage for each file
 $ pytest --cov
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,7 @@ follow_untyped_imports = "True"
 testpaths = [
     "tests",
 ]
-
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "serial",
+]

--- a/scripts/development-functions.sh
+++ b/scripts/development-functions.sh
@@ -15,6 +15,10 @@ run_coverage() {
   pytest --cov
 }
 
+run_tests() {
+  pytest -f -m "not slow"
+}
+
 run_mypy() {
   mypy --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs mantis
 }

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -126,6 +126,7 @@ def test_update_project_field_keys(mock_get, fake_jira: JiraClient):
         assert f.read() == '{"fields": []}'
 
 
+@pytest.mark.slow
 @patch("mantis.jira.jira_client.requests.get")
 def test_compile_plugins(mock_get, fake_jira: JiraClient):
     mock_get.return_value.json.return_value = {"name": "Testtype"}


### PR DESCRIPTION
Use [pytest marks](https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks) to skip slow tests.

```
$ pytest -f -m "not slow"
```