### PR TITLE
Use requests mock

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -109,7 +109,7 @@ class JiraClient:
             exit()
         issuetypes: dict[str, list[dict[str, Any]]] = response.json()
         assert isinstance(issuetypes, dict), f'issuetypes is not a dict: {issuetypes}'
-        assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got: {issuetypes}"
+        assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got keys: {list(issuetypes.keys())}"
         assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
         li = issuetypes['issueTypes']
         assert isinstance(li, list), f"issuetypes['issueTypes'] is not a list. Got: {issuetypes}"

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -205,6 +205,8 @@ class JiraClient:
     def test_auth(self) -> bool:
         try:
             user = self.get_current_user()
+            if not isinstance(user, dict):
+                raise ValueError(f"User is should be type dict. Got: {type(user)}")
             print(
                 f"Connected as user: {user.get('displayName', 'ERROR: No displayName')}"
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytest
 requests
+requests-mock
 types-requests
 requests.auth
 pytest-xdist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,9 @@
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
-from mantis.jira import JiraAuth, JiraClient, JiraIssues, JiraOptions
-from mantis.jira.utils.cache import Cache
+from mantis.jira import JiraAuth, JiraClient, JiraOptions
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,18 +24,6 @@ class Cli:
 
 
 @pytest.fixture
-def mock_post_request():
-    with patch("requests.post") as mock_post:
-        yield mock_post
-
-
-@pytest.fixture
-def mock_get_request():
-    with patch("requests.get") as mock_get:
-        yield mock_get
-
-
-@pytest.fixture
 def fake_toml(tmpdir):
     toml_contents = "\n".join(
         (
@@ -133,11 +121,9 @@ def fake_jira(
     with_fake_drafts_dir,
     with_fake_plugins_dir,
     jira_client_from_fake_cli,
-    mock_get_request,
     minimal_issue_payload,
 ):
     jira = jira_client_from_fake_cli
-    mock_get_request.return_value.json.return_value = minimal_issue_payload
     assert str(jira.cache.root) != ".jira_cache_test"
     assert str(jira.drafts_dir) != "drafts_test"
     assert str(jira.plugins_dir) != "plugins_test"

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -6,67 +6,67 @@ from .get_issuetypes_response import get_issuetypes_response
 
 class CacheData:
     @property
-    def ecs_1(self) -> Any:
+    def ecs_1(self) -> dict:
         with open('tests/data/jira_cache/issues/ECS-1.json', 'r') as f:
             return json.load(f)
 
     @property
-    def ecs_2(self) -> Any:
+    def ecs_2(self) -> dict:
         with open('tests/data/jira_cache/issues/ECS-2.json', 'r') as f:
             return json.load(f)
 
     @property
-    def ecs_3(self) -> Any:
+    def ecs_3(self) -> dict:
         with open('tests/data/jira_cache/issues/ECS-3.json', 'r') as f:
             return json.load(f)
 
     @property
-    def ecs_4(self) -> Any:
+    def ecs_4(self) -> dict:
         with open('tests/data/jira_cache/issues/ECS-4.json', 'r') as f:
             return json.load(f)
 
     @property
-    def ecs_5(self) -> Any:
+    def ecs_5(self) -> dict:
         with open('tests/data/jira_cache/issues/ECS-5.json', 'r') as f:
             return json.load(f)
 
     @property
-    def ecs_6(self) -> Any:
+    def ecs_6(self) -> dict:
         with open('tests/data/jira_cache/issues/ECS-6.json', 'r') as f:
             return json.load(f)
 
     @property
-    def issuetypes(self) -> Any:
+    def issuetypes(self) -> dict:
         with open('tests/data/jira_cache/system/issuetypes.json', 'r') as f:
             return json.load(f)
 
     @property
-    def projects(self) -> Any:
+    def projects(self) -> dict:
         with open('tests/data/jira_cache/system/projects.json', 'r') as f:
             return json.load(f)
 
     @property
-    def createmeta_bug(self) -> Any:
+    def createmeta_bug(self) -> dict:
         with open('tests/data/jira_cache/system/createmeta/createmeta_bug.json', 'r') as f:
             return json.load(f)
 
     @property
-    def createmeta_epic(self) -> Any:
+    def createmeta_epic(self) -> dict:
         with open('tests/data/jira_cache/system/createmeta/createmeta_epic.json', 'r') as f:
             return json.load(f)
 
     @property
-    def createmeta_story(self) -> Any:
+    def createmeta_story(self) -> dict:
         with open('tests/data/jira_cache/system/createmeta/createmeta_story.json', 'r') as f:
             return json.load(f)
 
     @property
-    def createmeta_subtask(self) -> Any:
+    def createmeta_subtask(self) -> dict:
         with open('tests/data/jira_cache/system/createmeta/createmeta_subtask.json', 'r') as f:
             return json.load(f)
 
     @property
-    def createmeta_task(self) -> Any:
+    def createmeta_task(self) -> dict:
         with open('tests/data/jira_cache/system/createmeta/createmeta_task.json', 'r') as f:
             return json.load(f)
 

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -69,3 +69,11 @@ class CacheData:
     def createmeta_task(self) -> Any:
         with open('tests/data/jira_cache/system/createmeta/createmeta_task.json', 'r') as f:
             return json.load(f)
+
+    @property
+    def placeholder_account(self) -> dict[str, str]:
+        return {
+            "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
+            "emailAddress": "marcus@rome.gov",
+            "displayName": "Marcus Aurelius",
+        }

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -35,16 +35,16 @@ def test_cache_exists(fake_jira: JiraClient):
         assert item.name in ("createmeta", "editmeta")
 
 
-@pytest.fixture
-def json_response_account_id(mock_get_request):
-    mock_get_request.return_value.json.return_value = {
-        "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
-        "emailAddress": "user@domain.com",
-        "displayName": "Marcus Aurelius",
-    }
+json_response_account = {
+    "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
+    "emailAddress": "user@domain.com",
+    "displayName": "Marcus Aurelius",
+}
 
 
-def test_get_current_user(fake_jira: JiraClient, json_response_account_id):
+def test_get_current_user(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/myself', json=json_response_account)
     assert fake_jira.get_current_user() == {
         "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
         "emailAddress": "user@domain.com",
@@ -52,20 +52,26 @@ def test_get_current_user(fake_jira: JiraClient, json_response_account_id):
     }
 
 
-def test_get_current_user_account_id(fake_jira: JiraClient, json_response_account_id):
+def test_get_current_user_account_id(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/myself', json=json_response_account)
     assert (
         fake_jira.get_current_user_account_id()
         == "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"
     )
 
 
-def test_get_current_user_as_assignee(fake_jira: JiraClient, json_response_account_id):
+def test_get_current_user_as_assignee(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/myself', json=json_response_account)
     assert fake_jira.get_current_user_as_assignee() == {
         "assignee": {"accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"}
     }
 
 
-def test_get_test_auth_success(fake_jira: JiraClient, json_response_account_id, capsys):
+def test_get_test_auth_success(fake_jira: JiraClient, capsys, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/myself', json=json_response_account)
     assert fake_jira.test_auth()
     captured = capsys.readouterr()
     assert captured.out == "Connected as user: Marcus Aurelius\n"

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -8,8 +8,7 @@ from tests.data import CacheData
 
 
 def test_test_auth_complains_with_bad_input(requests_mock, fake_jira: JiraClient, capsys):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json={})
+    requests_mock.get(f'{fake_jira.api_url}/myself', json={})
     fake_jira.test_auth()
     captured = capsys.readouterr()
     assert captured.out == ("Connected as user: ERROR: No displayName\n")
@@ -17,8 +16,7 @@ def test_test_auth_complains_with_bad_input(requests_mock, fake_jira: JiraClient
 
 
 def test_test_auth_informs_login(requests_mock, fake_jira: JiraClient, capsys):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json={'displayName': 'Buddy'})
+    requests_mock.get(f'{fake_jira.api_url}/myself', json={'displayName': 'Buddy'})
     fake_jira.test_auth()
     captured = capsys.readouterr()
     assert captured.out == ("Connected as user: Buddy\n")
@@ -37,8 +35,7 @@ def test_cache_exists(fake_jira: JiraClient):
 
 
 def test_get_current_user(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
+    requests_mock.get(f'{fake_jira.api_url}/myself', json=CacheData().placeholder_account)
     assert fake_jira.get_current_user() == {
         "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
         "emailAddress": "marcus@rome.gov",
@@ -47,8 +44,7 @@ def test_get_current_user(fake_jira: JiraClient, requests_mock):
 
 
 def test_get_current_user_account_id(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
+    requests_mock.get(f'{fake_jira.api_url}/myself', json=CacheData().placeholder_account)
     assert (
         fake_jira.get_current_user_account_id()
         == "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"
@@ -56,16 +52,14 @@ def test_get_current_user_account_id(fake_jira: JiraClient, requests_mock):
 
 
 def test_get_current_user_as_assignee(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
+    requests_mock.get(f'{fake_jira.api_url}/myself', json=CacheData().placeholder_account)
     assert fake_jira.get_current_user_as_assignee() == {
         "assignee": {"accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"}
     }
 
 
 def test_get_test_auth_success(fake_jira: JiraClient, capsys, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
+    requests_mock.get(f'{fake_jira.api_url}/myself', json=CacheData().placeholder_account)
     assert fake_jira.test_auth()
     captured = capsys.readouterr()
     assert captured.out == "Connected as user: Marcus Aurelius\n"

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -6,10 +6,22 @@ import requests
 from mantis.jira import JiraClient
 
 
-@patch("mantis.jira.jira_client.requests.get")
-def test_jira_options_override(mock_get, fake_jira: JiraClient):
-    mock_get.return_value.json.return_value = {}
+def test_test_auth_complains_with_bad_input(requests_mock, fake_jira: JiraClient, capsys):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/myself', json={})
     fake_jira.test_auth()
+    captured = capsys.readouterr()
+    assert captured.out == ("Connected as user: ERROR: No displayName\n")
+    assert captured.err == ""
+
+
+def test_test_auth_informs_login(requests_mock, fake_jira: JiraClient, capsys):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/myself', json={'displayName': 'Buddy'})
+    fake_jira.test_auth()
+    captured = capsys.readouterr()
+    assert captured.out == ("Connected as user: Buddy\n")
+    assert captured.err == ""
 
 
 def test_cache_exists(fake_jira: JiraClient):

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 
 from mantis.jira import JiraClient
+from tests.data import CacheData
 
 
 def test_test_auth_complains_with_bad_input(requests_mock, fake_jira: JiraClient, capsys):
@@ -35,26 +36,19 @@ def test_cache_exists(fake_jira: JiraClient):
         assert item.name in ("createmeta", "editmeta")
 
 
-json_response_account = {
-    "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
-    "emailAddress": "user@domain.com",
-    "displayName": "Marcus Aurelius",
-}
-
-
 def test_get_current_user(fake_jira: JiraClient, requests_mock):
     api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=json_response_account)
+    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
     assert fake_jira.get_current_user() == {
         "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
-        "emailAddress": "user@domain.com",
+        "emailAddress": "marcus@rome.gov",
         "displayName": "Marcus Aurelius",
     }
 
 
 def test_get_current_user_account_id(fake_jira: JiraClient, requests_mock):
     api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=json_response_account)
+    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
     assert (
         fake_jira.get_current_user_account_id()
         == "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"
@@ -63,7 +57,7 @@ def test_get_current_user_account_id(fake_jira: JiraClient, requests_mock):
 
 def test_get_current_user_as_assignee(fake_jira: JiraClient, requests_mock):
     api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=json_response_account)
+    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
     assert fake_jira.get_current_user_as_assignee() == {
         "assignee": {"accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"}
     }
@@ -71,7 +65,7 @@ def test_get_current_user_as_assignee(fake_jira: JiraClient, requests_mock):
 
 def test_get_test_auth_success(fake_jira: JiraClient, capsys, requests_mock):
     api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/myself', json=json_response_account)
+    requests_mock.get(f'{api_url}/myself', json=CacheData().placeholder_account)
     assert fake_jira.test_auth()
     captured = capsys.readouterr()
     assert captured.out == "Connected as user: Marcus Aurelius\n"

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -72,7 +72,7 @@ def test_get_test_auth_success(fake_jira: JiraClient, json_response_account_id, 
     assert captured.err == ""
 
 
-def test_get_test_auth_connection_error(fake_jira: JiraClient, json_response_account_id, capsys):
+def test_get_test_auth_connection_error(fake_jira: JiraClient, capsys):
     with patch(
         "mantis.jira.jira_client.requests.get",
         side_effect=requests.exceptions.ConnectionError,
@@ -90,7 +90,7 @@ def test_get_test_auth_connection_error(fake_jira: JiraClient, json_response_acc
     assert captured.err == ""
 
 
-def test_get_test_auth_generic_exception(fake_jira: JiraClient, json_response_account_id, capsys):
+def test_get_test_auth_generic_exception(fake_jira: JiraClient, capsys):
     with patch(
         "mantis.jira.jira_client.requests.get",
         side_effect=requests.exceptions.RequestException,

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -1,6 +1,5 @@
 import pytest
 
-from mantis.drafts import Draft
 from mantis.jira import JiraClient
 from mantis.jira.jira_issues import JiraIssue
 from tests.data import CacheData

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -7,11 +7,10 @@ from tests.data import CacheData
 
 
 def test_jira_draft(fake_jira: JiraClient, minimal_issue_payload, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
     ecs_1 = CacheData().ecs_1
     ecs_1['fields']['assignee'] = {"displayName": "Bobby Goodsky"}
-    requests_mock.get(f'{api_url}/issue/ECS-1', json=ecs_1)
-    requests_mock.get(f'{api_url}/issue/ECS-2', json=CacheData().ecs_2)
+    requests_mock.get(f'{fake_jira.api_url}/issue/ECS-1', json=ecs_1)
+    requests_mock.get(f'{fake_jira.api_url}/issue/ECS-2', json=CacheData().ecs_2)
 
     minimal_issue_payload['fields']['assignee'] = {"displayName": "Bobby Goodsky"}
     assert str(fake_jira.cache.root) != ".jira_cache_test"
@@ -55,8 +54,7 @@ def test_jira_draft(fake_jira: JiraClient, minimal_issue_payload, requests_mock)
             assert content.strip() in expectations, f"content.strip() ({content.strip()}) not in expectations in: {expectations}"
 
 def test_read_draft(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/issue/ECS-1', json=CacheData().ecs_1)
+    requests_mock.get(f'{fake_jira.api_url}/issue/ECS-1', json=CacheData().ecs_1)
 
     issue_key = 'ECS-1'
     issue = fake_jira.issues.get(key=issue_key)

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -3,56 +3,66 @@ import pytest
 from mantis.drafts import Draft
 from mantis.jira import JiraClient
 from mantis.jira.jira_issues import JiraIssue
+from tests.data import CacheData
 
 
-def test_jira_draft(fake_jira: JiraClient, minimal_issue_payload):
+def test_jira_draft(fake_jira: JiraClient, minimal_issue_payload, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    ecs_1 = CacheData().ecs_1
+    ecs_1['fields']['assignee'] = {"displayName": "Bobby Goodsky"}
+    requests_mock.get(f'{api_url}/issue/ECS-1', json=ecs_1)
+    requests_mock.get(f'{api_url}/issue/ECS-2', json=CacheData().ecs_2)
+
     minimal_issue_payload['fields']['assignee'] = {"displayName": "Bobby Goodsky"}
     assert str(fake_jira.cache.root) != ".jira_cache_test"
     assert str(fake_jira.drafts_dir) != "drafts_test"
     
     assert len(list(fake_jira.drafts_dir.iterdir())) == 0
-    task_1 = fake_jira.issues.get("TASK-1")
+    task_1 = fake_jira.issues.get("ECS-1")
     assert len([*fake_jira.drafts_dir.iterdir()]) == 1
     assert isinstance(task_1, JiraIssue)
 
-    minimal_issue_payload['key'] = "TASK-2"
-    task_2 = fake_jira.issues.get("TASK-2")
+    minimal_issue_payload['key'] = "ECS-2"
+    task_2 = fake_jira.issues.get("ECS-2")
     assert len([*fake_jira.drafts_dir.iterdir()]) == 2
 
-    with open(fake_jira.drafts_dir / "TASK-1.md", "r") as f:
+    with open(fake_jira.drafts_dir / "ECS-1.md", "r") as f:
         content = f.read()
     assert "assignee: Bobby Goodsky" in content
-    assert "Bobby Goodsky" == fake_jira.issues.get('TASK-1').draft.issue.get_field("assignee", {}).get(
+    assert "Bobby Goodsky" == fake_jira.issues.get('ECS-1').draft.issue.get_field("assignee", {}).get(
         "displayName", ""
     )
     expectations = (
         "---",
-        "header: '[TASK-1] redacted'",
+        "header: '[ECS-1] (Sample) User Authentication'",
         "ignore: true",
-        "parent: redacted",
-        "summary: redacted",
+        "parent: null",
+        "summary: (Sample) User Authentication",
         "issuetype:",
-        "issuetype: Task",
-        "project: redacted",
-        "reporter: redacted",
+        "issuetype: Epic",
+        "project: E-Commerce Checkout System",
+        "reporter: Casper Lehmann",
         "description: redacted",
         "assignee: Bobby Goodsky",
-        "status: resolved",
+        "status: In Progress",
         "---",
-        "# redacted",
+        "# (Sample) User Authentication",
         "",
-        "redacted",
+        "Implement user authentication for the checkout system.",
     )
-    with open(fake_jira.drafts_dir / "TASK-1.md", "r") as f:
+    with open(fake_jira.drafts_dir / "ECS-1.md", "r") as f:
         for content in f.readlines():
             assert content.strip() in expectations, f"content.strip() ({content.strip()}) not in expectations in: {expectations}"
 
-def test_read_draft(fake_jira: JiraClient):
-    issue_key = 'TEST-1'
+def test_read_draft(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/issue/ECS-1', json=CacheData().ecs_1)
+
+    issue_key = 'ECS-1'
     issue = fake_jira.issues.get(key=issue_key)
     draft_data = issue.draft.read_draft()
     assert draft_data
-    assert draft_data.content == "redacted"
+    assert draft_data.content == "Implement user authentication for the checkout system."
     assert set(draft_data.keys()) == {
         'assignee',
         'header',

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -25,8 +25,8 @@ def test_config_loader_update_issuetypes_writes_to_cache(fake_jira: JiraClient, 
 def test_persisted_issuetypes_data():
     cache_data = CacheData()
     assert hasattr(cache_data, 'issuetypes')
-    selector = lambda field_name: {_[field_name] for _ in cache_data.issuetypes.get("issueTypes")}
-    assert len(cache_data.issuetypes.get("issueTypes")) == 5
+    selector = lambda field_name: {_[field_name] for _ in cache_data.issuetypes.get("issueTypes", {field_name: ''})}
+    assert len(cache_data.issuetypes.get("issueTypes", [])) == 5
     assert selector('name') == {'Subtask', 'Story', 'Bug', 'Task', 'Epic'}
 
 

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -11,8 +11,7 @@ from tests.data import get_issuetypes_response, update_projects_cache_response, 
 
 
 def test_config_loader_update_issuetypes_writes_to_cache(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=get_issuetypes_response)
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=get_issuetypes_response)
     set_with_no_issuetypes = {str(_).split('/')[-1] for _ in fake_jira.cache.system.iterdir()}
     assert set_with_no_issuetypes == {'createmeta', 'editmeta'}, (
         f"System cache expected 2 values. Got: {set_with_no_issuetypes}")
@@ -31,8 +30,7 @@ def test_persisted_issuetypes_data():
 
 
 def test_cache_get_issuetypes_from_system_cache(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=get_issuetypes_response)
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=get_issuetypes_response)
     cache = fake_jira.cache
     with open(fake_jira.cache.system / "issuetypes.json", "w") as f:
         json.dump(CacheData().issuetypes, f)
@@ -47,8 +45,7 @@ def test_cache_get_issuetypes_from_system_cache(fake_jira: JiraClient, requests_
 
 
 def test_config_loader_loop_yields_files(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=get_issuetypes_response)
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=get_issuetypes_response)
     assert len(list(fake_jira.system_config_loader.loop_createmeta())) == 0
     # cache something
     with open(fake_jira.cache.createmeta / f"some_file.json", "w") as f:
@@ -57,9 +54,7 @@ def test_config_loader_loop_yields_files(fake_jira: JiraClient, requests_mock):
 
 
 def test_update_project_field_keys(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    # Mock projects response
-    requests_mock.get(f'{api_url}/project', json=update_projects_cache_response)
+    requests_mock.get(f'{fake_jira.api_url}/project', json=update_projects_cache_response)
 
     # Test initial state
     if (fake_jira.cache.system / 'projects.json').exists():
@@ -88,8 +83,7 @@ def test_update_project_field_keys(fake_jira: JiraClient, requests_mock):
         'We expect two projects in len(update_projects_cache_response): '
         f'{len(update_projects_cache_response)} Got {got_project_ids_as_ints}')
     
-    # Mock issuetypes response
-    requests_mock.get(f'{api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=CacheData().issuetypes)
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/{fake_jira.project_name}/issuetypes', json=CacheData().issuetypes)
 
     # Fetch and cache issuetypes data
     if (fake_jira.cache.system / 'issuetypes.json').exists():
@@ -108,11 +102,11 @@ def test_update_project_field_keys(fake_jira: JiraClient, requests_mock):
         raise FileNotFoundError('File "issuetypes.json" should have been created')
 
     # Mock createmeta response
-    requests_mock.get(f'{api_url}/issue/createmeta/TEST/issuetypes/10001', json={'fields': []})
-    requests_mock.get(f'{api_url}/issue/createmeta/TEST/issuetypes/10002', json={'fields': []})
-    requests_mock.get(f'{api_url}/issue/createmeta/TEST/issuetypes/10003', json={'fields': []})
-    requests_mock.get(f'{api_url}/issue/createmeta/TEST/issuetypes/10004', json={'fields': []})
-    requests_mock.get(f'{api_url}/issue/createmeta/TEST/issuetypes/10005', json={'fields': []})
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/TEST/issuetypes/10001', json={'fields': []})
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/TEST/issuetypes/10002', json={'fields': []})
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/TEST/issuetypes/10003', json={'fields': []})
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/TEST/issuetypes/10004', json={'fields': []})
+    requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/TEST/issuetypes/10005', json={'fields': []})
 
     if (fake_jira.cache.createmeta / 'createmeta_story.json').exists():
         raise FileExistsError('File "createmeta_story.json" should not exist yet')
@@ -127,8 +121,7 @@ def test_update_project_field_keys(fake_jira: JiraClient, requests_mock):
 
 @pytest.mark.slow
 def test_compile_plugins(fake_jira: JiraClient, requests_mock):
-    api_url = fake_jira.options.url + "/rest/api/latest"
-    requests_mock.get(f'{api_url}/project', json={"name": "Testtype"})
+    requests_mock.get(f'{fake_jira.api_url}/project', json={"name": "Testtype"})
     assert str(fake_jira.plugins_dir) != ".jira_cache_test"
 
     with open(fake_jira.cache.createmeta / "Testtype.json", "w") as f:

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -126,20 +126,16 @@ def test_update_project_field_keys(fake_jira: JiraClient, requests_mock):
 
 
 @pytest.mark.slow
-@patch("mantis.jira.jira_client.requests.get")
-def test_compile_plugins(mock_get, fake_jira: JiraClient):
-    mock_get.return_value.json.return_value = {"name": "Testtype"}
+def test_compile_plugins(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/project', json={"name": "Testtype"})
     assert str(fake_jira.plugins_dir) != ".jira_cache_test"
-
-    config_loader = fake_jira.system_config_loader
 
     with open(fake_jira.cache.createmeta / "Testtype.json", "w") as f:
         f.write('{"name": "Testtype"}')
 
-    assert (
-        len(list(fake_jira.plugins_dir.iterdir())) == 0
-    ), f"Not empty: {fake_jira.plugins_dir}"
-    config_loader.compile_plugins()
+    assert (len(list(fake_jira.plugins_dir.iterdir())) == 0), f"Not empty: {fake_jira.plugins_dir}"
+    fake_jira.system_config_loader.compile_plugins()
     assert len(list(fake_jira.plugins_dir.iterdir())) == 1
 
 

--- a/tests/test_jira_fetch_enums.py
+++ b/tests/test_jira_fetch_enums.py
@@ -1,6 +1,5 @@
 import json
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 from unittest.mock import Mock, patch
 

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -9,12 +9,16 @@ from requests.models import HTTPError
 from mantis.jira import JiraClient
 from mantis.jira.jira_client import process_key
 from mantis.jira.jira_issues import JiraIssues
+from tests.data import CacheData
 
 
-def test_jira_issues_get_fake(fake_jira: JiraClient):
-    task_1 = fake_jira.issues.get("TASK-1")
-    assert task_1.get("key") == "TASK-1"
-    assert task_1.get("fields", {}).get("status") == {"name": "resolved"}  # type: ignore None risk of second get. Since it's explicitly returning a dict as default.
+def test_jira_issues_get_fake(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/issue/ECS-1', json=CacheData().ecs_1)
+
+    task_1 = fake_jira.issues.get("ECS-1")
+    assert task_1.get("key") == "ECS-1"
+    assert task_1.get("fields", {})["status"]['name'] == "In Progress"
 
 
 def test_jira_issues_get_mocked(fake_jira: JiraClient, with_no_read_cache, minimal_issue_payload):
@@ -98,9 +102,9 @@ def test_process_key():
             process_key(key="A-B-1", exception=e)
 
 
-def test_handle_http_error_raises_generic_exception(
-    fake_jira: "JiraClient", mock_post_request
-):
+def test_handle_http_error_raises_generic_exception(fake_jira: "JiraClient", requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/issue/ECS-1', json=CacheData().ecs_1)
     mock_response = Mock()
     mock_response.reason = "Unknown error"
     mock_response.raise_for_status.side_effect = HTTPError()
@@ -117,8 +121,10 @@ def test_handle_http_error_raises_generic_exception(
                 fake_jira.handle_http_error(exception=e, key="A-1")
 
 
-def test_jira_no_issues_fields_raises(fake_jira: JiraClient, mock_post_request):
-    issue = fake_jira.issues.get("TASK-1")
+def test_jira_no_issues_fields_raises(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+    requests_mock.get(f'{api_url}/issue/ECS-1', json=CacheData().ecs_1)
+    issue = fake_jira.issues.get("ECS-1")
     issue.data["fields"] = None  # type: ignore since we are purely testing that it raises an error
     with pytest.raises(KeyError):
         assert issue.fields
@@ -139,15 +145,18 @@ def test_jira_issues_cached_issuetypes_parses_allowed_types(fake_jira: JiraClien
     assert fake_jira.issues.allowed_types == ["Bug", "Task"], f'Unexpected allowed types: {fake_jira.issues._allowed_types}'
     assert fake_jira.issues._allowed_types
 
-def test_jira_issues_get_does_write_to_cache(fake_jira: JiraClient):
-    assert fake_jira.cache.get_issue("TASK-1") is None
+def test_jira_issues_get_does_write_to_cache(fake_jira: JiraClient, requests_mock):
+    api_url = fake_jira.options.url + "/rest/api/latest"
+
+    assert fake_jira.cache.get_issue("ECS-1") is None
     assert len([file for file in fake_jira.cache.issues.iterdir()]) == 0
-    issue = fake_jira.issues.get("TASK-1")
-    assert fake_jira.cache.get_issue("TASK-1")
+    requests_mock.get(f'{api_url}/issue/ECS-1', json=CacheData().ecs_1)
+    issue = fake_jira.issues.get("ECS-1")
+    assert fake_jira.cache.get_issue("ECS-1")
     assert len([file for file in fake_jira.cache.issues.iterdir()]) == 1
-    with open(fake_jira.cache.issues / "TASK-1.json", "r") as f:
+    with open(fake_jira.cache.issues / "ECS-1.json", "r") as f:
         data = json.load(f)
-    assert data["key"] == "TASK-1"
+    assert data["key"] == "ECS-1"
 
 
 def test_jira_issues_get_does_retrieve_from_cache(fake_jira: JiraClient, minimal_issue_payload):


### PR DESCRIPTION
Remove global `mock_post_request` and `mock_get_request` from test suite and start using `requests-mock` library instead.

Rely on `CacheData` class in more test cases.