### PR TITLE
Fix createmeta cache write location and typing

### DIFF
--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -127,7 +127,7 @@ class JiraClient:
         issuetype_id = one_issuetype['id']
         return issuetype_id
 
-    def get_createmeta(self, issuetype_id: str) -> dict[str, list[dict[str, Any]]]:
+    def get_createmeta(self, issuetype_id: str) -> dict[str, int | list[dict[str, Any]]]:
         """Createmeta dict with a list of fields called 'fields'"""
         url = f"issue/createmeta/{self.project_name}/issuetypes/{issuetype_id}"
         response = self._get(url)

--- a/mantis/jira/jira_issues.py
+++ b/mantis/jira/jira_issues.py
@@ -47,7 +47,7 @@ class JiraIssue:
         return self.data['fields']['issuetype']['name']
 
     @property
-    def createmeta_data(self) -> dict[str, list[dict[str, Any]]]:
+    def createmeta_data(self) -> dict[str, int | list[dict[str, Any]]]:
         self._createmeta_data = self.client.system_config_loader.get_createmeta(self.issuetype)
         return self._createmeta_data
 

--- a/mantis/jira/utils/cache.py
+++ b/mantis/jira/utils/cache.py
@@ -116,7 +116,7 @@ class Cache:
     def write_issuetypes_to_system_cache(self, issuetypes: dict[str, Any]) -> None:
         self.write_to_system_cache("issuetypes.json", json.dumps(issuetypes))
 
-    def write_createmeta(self, issuetype_name: str, createmeta: dict[str, int | dict]) -> None:
+    def write_createmeta(self, issuetype_name: str, createmeta: dict[str, int | list[dict[str, Any]]]) -> None:
         filename = f"createmeta_{issuetype_name.lower()}.json"
         self._write(self.createmeta, filename, json.dumps(createmeta))
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -225,11 +225,13 @@ class JiraSystemConfigLoader:
                 return from_cache
         issuetype_id = self.client.issuetype_name_to_id(issuetype_name)
         createmeta = self.client.get_createmeta(issuetype_id)
-        assert isinstance(createmeta, dict)
+        if not isinstance(createmeta, dict):
+            raise ValueError(f'The createmeta object should be a dict. Got: {type(createmeta)}')
         if len(createmeta.keys()) == 0:
             raise ValueError(
                 'No content in createmeta. Something is probably very wrong.')
-        assert 'fields' in createmeta, f'createmeta has no fields {createmeta.keys()}'
+        if not 'fields' in createmeta:
+            raise ValueError(f'The createmeta has no fields. Got: {createmeta.keys()}')
         self.cache.write_createmeta(issuetype_name, createmeta)
         return createmeta
 

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -224,14 +224,14 @@ class JiraSystemConfigLoader:
             if from_cache:
                 return from_cache
         issuetype_id = self.client.issuetype_name_to_id(issuetype_name)
-        issuetypes = self.client.get_createmeta(issuetype_id)
-        assert isinstance(issuetypes, dict)
-        if len(issuetypes.keys()) == 0:
+        createmeta = self.client.get_createmeta(issuetype_id)
+        assert isinstance(createmeta, dict)
+        if len(createmeta.keys()) == 0:
             raise ValueError(
-                'List of issuetypes has length of zero. Something is probably very wrong.')
-        assert 'issueTypes' in issuetypes, f'issueTypes has no issueTypes {issuetypes}'
-        self.cache.write_issuetypes_to_system_cache(issuetypes)
-        return issuetypes
+                'No content in createmeta. Something is probably very wrong.')
+        assert 'fields' in createmeta, f'createmeta has no fields {createmeta.keys()}'
+        self.cache.write_createmeta(issuetype_name, createmeta)
+        return createmeta
 
     def fetch_and_update_all_createmeta(self) -> list[str]:
         """Updates all createmate from upstream, returns updated list of allowed types"""

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -218,7 +218,7 @@ class JiraSystemConfigLoader:
         self.cache.write_issuetypes_to_system_cache(issuetypes)
         return issuetypes
 
-    def get_createmeta(self, issuetype_name: str, force_skip_cache: bool = False) -> dict[str, list[dict[str, Any]]]:
+    def get_createmeta(self, issuetype_name: str, force_skip_cache: bool = False) -> dict[str, int | list[dict[str, Any]]]:
         if not self.client._no_read_cache or force_skip_cache:
             from_cache = self.cache.get_createmeta_from_cache(issuetype_name)
             if from_cache:


### PR DESCRIPTION
In `jira_system_config_loader.py`, the `get_createmeta` method was writing to the wrong file.
After getting the `createmeta` from upstream, it was written to disk using `write_issuetypes_to_system_cache`.
```diff
-         issuetypes = self.client.get_createmeta(issuetype_id)
+         createmeta = self.client.get_createmeta(issuetype_id)
  ...
-         self.cache.write_issuetypes_to_system_cache(issuetypes)
-         return issuetypes
+         self.cache.write_createmeta(issuetype_name, createmeta)
+         return createmeta
```
This means that `createmeta` was written correctly, and the `issuetypes` would by corrupted.

Since the schemas of the `issuetypes` object and `createmeta` differ, this caused a number of typing issues across the repo as well. I'm fixing that while I'm at it.