### PR TITLE
Init auto-complete

### DIFF
--- a/main.py
+++ b/main.py
@@ -134,6 +134,9 @@ if __name__ == '__main__':
             except KeyError:
                 print()
 
+    elif jira_options.action == 'auto-complete':
+        auto_complete_suggestions = jira.auto_complete.get_suggestions("reporter", 'Casper')
+        print(auto_complete_suggestions)
     elif jira_options.action == 'get-project-keys':
         print ('Fetching from Jira...')
         resp = jira.system_config_loader.fetch_and_update_all_createmeta()

--- a/mantis/jira/auto_complete.py
+++ b/mantis/jira/auto_complete.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from mantis.jira.jira_client import JiraClient
+
+
+class Suggestion:
+    def __init__(self, entry: dict[str, str]): # display_name: str, value: str):
+        assert entry.get('displayName')
+        self.display_name = entry['displayName'].replace('<b>', '').replace('</b>', '')
+        self.value = entry.get('value')
+
+    def __repr__(self) -> str:
+        return f"Suggestion(display_name={self.display_name}, value={self.value})"
+
+
+class AutoComplete:
+    def __init__(self, jira: "JiraClient") -> None:
+        self.jira = jira
+
+    def get_suggestions(self, field_name: str, field_value: str) -> list[Suggestion]:
+        data = self.jira.jql_auto_complete(field_name, field_value)
+        return [Suggestion(entry) for entry in data.get('results', [])]

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -201,7 +201,22 @@ class JiraClient:
             print (e.response.json() )
             exit()
         return True
-    
+
+    def jql_auto_complete(self, field_name: str, field_value: str) -> dict[str, Any]:
+        uri = f"jql/autocompletedata/suggestions"
+        query = {
+            'fieldName': field_name,
+            'fieldValue': field_value,
+        }
+        response = self._get(uri, query)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print (e.response.reason )
+            print (e.response.json() )
+            exit()
+        return response.json()
+
     def test_auth(self) -> bool:
         try:
             user = self.get_current_user()

--- a/mantis/jira/jira_client.py
+++ b/mantis/jira/jira_client.py
@@ -5,6 +5,7 @@ import requests
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mantis.jira.auto_complete import AutoComplete
 from mantis.jira.jira_issues import JiraIssues
 from mantis.jira.utils import Cache, JiraSystemConfigLoader
 
@@ -50,6 +51,7 @@ class JiraClient:
         self.plugins_dir.mkdir(exist_ok=True)
         self.system_config_loader = JiraSystemConfigLoader(self)
         self.issues = JiraIssues(self)
+        self.auto_complete = AutoComplete(self)
 
     @property
     def drafts_dir(self) -> Path:

--- a/tests/test_jira_autocomplete.py
+++ b/tests/test_jira_autocomplete.py
@@ -1,0 +1,10 @@
+from mantis.jira.jira_client import JiraClient
+
+
+class TestJiraAutocomplete:
+    def test_get_suggestions(self, fake_jira: JiraClient, requests_mock):
+        return_value = {'results': [{'value': 'abc123', 'displayName': '<b>Marcus</b> Aurelius - <b>marcus</b>@rome.gov'}]}
+        requests_mock.get(fake_jira.api_url + '/jql/autocompletedata/suggestions?fieldName=reporter&fieldValue=Marcus', json=return_value)
+        suggestions = fake_jira.auto_complete.get_suggestions('reporter', 'Marcus')
+        assert len(suggestions) == 1
+        assert suggestions[0].display_name == 'Marcus Aurelius - marcus@rome.gov'


### PR DESCRIPTION
In order to validate input, use the JQL auto-complete input for a quick check.
- https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-jql/#api-rest-api-3-jql-autocompletedata-suggestions-get

We'll hook it up later.