### PR TITLE
Add accessors to Draft

### DIFF
--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -82,6 +82,14 @@ class Draft:
         draft_data = self.remove_draft_header(draft_data)
         return draft_data
 
+    def iter_draft_field_keys(self):
+        local_vars = ('ignore', 'header')
+        draft_data = self.read_draft()
+        for draft_field_key in draft_data.keys():
+            if draft_field_key in local_vars:  # E.g. Local custom fields
+                continue
+            yield draft_field_key
+
     def get(self, key: str, default: Any = None) -> Any:
         local_vars = ('ignore', 'header')
         draft_data = self.read_draft()

--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 import frontmatter  # type: ignore
 
@@ -81,3 +81,8 @@ class Draft:
             draft_data = frontmatter.load(f)
         draft_data = self.remove_draft_header(draft_data)
         return draft_data
+
+    def get(self, key: str, default: Any = None) -> Any:
+        local_vars = ('ignore', 'header')
+        draft_data = self.read_draft()
+        return draft_data.get(key, default)

--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING, Generator
 
 import frontmatter  # type: ignore
 
@@ -82,7 +82,7 @@ class Draft:
         draft_data = self.remove_draft_header(draft_data)
         return draft_data
 
-    def iter_draft_field_items(self):
+    def iter_draft_field_items(self) -> Generator[tuple[str, Any], None, None]:
         local_vars = ('ignore', 'header')
         draft_data = self.read_draft()
         for draft_field_key in draft_data.keys():
@@ -90,7 +90,7 @@ class Draft:
                 continue
             yield draft_field_key, draft_data.get(draft_field_key)
 
-    def iter_draft_field_keys(self):
+    def iter_draft_field_keys(self) -> Generator[str, None, None]:
         local_vars = ('ignore', 'header')
         draft_data = self.read_draft()
         for draft_field_key in draft_data.keys():

--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -82,6 +82,14 @@ class Draft:
         draft_data = self.remove_draft_header(draft_data)
         return draft_data
 
+    def iter_draft_field_items(self):
+        local_vars = ('ignore', 'header')
+        draft_data = self.read_draft()
+        for draft_field_key in draft_data.keys():
+            if draft_field_key in local_vars:  # E.g. Local custom fields
+                continue
+            yield draft_field_key, draft_data.get(draft_field_key)
+
     def iter_draft_field_keys(self):
         local_vars = ('ignore', 'header')
         draft_data = self.read_draft()


### PR DESCRIPTION
Adding accessors to `Draft`, in order to simplify other WIP: `iter_draft_field_items`, `iter_draft_field_keys`, `get`.