### PR TITLE
Create field_by_key methods for MetaModelFactory

### DIFF
--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -32,7 +32,11 @@ class MetaModelFactory(ABC):
         if "fields" not in metadata.keys():
             raise ValueError(
                 f'The provided data "metadata" does not contain a keys named "fields". Got: {metadata.keys()}')
-    
+
+    @abstractmethod
+    def field_by_key(self, key: str):
+        pass
+
     @property
     def meta_fields(self) -> list[dict[str, Any]] | dict[str, dict[str, Any]]:
         return self.metadata["fields"]
@@ -145,6 +149,8 @@ class CreatemetaModelFactory(MetaModelFactory):
                 f'CreatemetaModelFactory.meta_fields should be of type list. Got: {type(self.meta_fields)}')
         self.create_model()
 
+    def field_by_key(self, key: str, default: Any | None = None):
+        return next((item for item in self._iter_meta_fields if item.get('key') == key), default)
 
 class EditmetaModelFactory(MetaModelFactory):
     process = 'editmeta'
@@ -166,6 +172,8 @@ class EditmetaModelFactory(MetaModelFactory):
                 f'EditmetaModelFactory.meta_fields should be of type dict. Got: {type(self.meta_fields)}')
         self.create_model()
 
+    def field_by_key(self, key: str, default: Any | None = None):
+        return self.meta_fields.get(key, default)
 
 class JiraSystemConfigLoader:
     def __init__(self, client: "JiraClient") -> None:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -173,6 +173,7 @@ class EditmetaModelFactory(MetaModelFactory):
         self.create_model()
 
     def field_by_key(self, key: str, default: Any | None = None) -> Any | None:
+        assert isinstance(self.meta_fields, dict), 'Asserting to satisfy type checker.'
         return self.meta_fields.get(key, default)
 
 class JiraSystemConfigLoader:

--- a/mantis/jira/utils/jira_system_config_loader.py
+++ b/mantis/jira/utils/jira_system_config_loader.py
@@ -34,7 +34,7 @@ class MetaModelFactory(ABC):
                 f'The provided data "metadata" does not contain a keys named "fields". Got: {metadata.keys()}')
 
     @abstractmethod
-    def field_by_key(self, key: str):
+    def field_by_key(self, key: str) -> Any | None:
         pass
 
     @property
@@ -149,7 +149,7 @@ class CreatemetaModelFactory(MetaModelFactory):
                 f'CreatemetaModelFactory.meta_fields should be of type list. Got: {type(self.meta_fields)}')
         self.create_model()
 
-    def field_by_key(self, key: str, default: Any | None = None):
+    def field_by_key(self, key: str, default: Any | None = None) -> Any | None:
         return next((item for item in self._iter_meta_fields if item.get('key') == key), default)
 
 class EditmetaModelFactory(MetaModelFactory):
@@ -172,7 +172,7 @@ class EditmetaModelFactory(MetaModelFactory):
                 f'EditmetaModelFactory.meta_fields should be of type dict. Got: {type(self.meta_fields)}')
         self.create_model()
 
-    def field_by_key(self, key: str, default: Any | None = None):
+    def field_by_key(self, key: str, default: Any | None = None) -> Any | None:
         return self.meta_fields.get(key, default)
 
 class JiraSystemConfigLoader:


### PR DESCRIPTION
Add `field_by_key` to `CreatemetaModelFactory` and `EditmetaModelFactory`, allowing us to fetch field meta through a unified interface.