### PR TITLE
Tests must always pass fake toml

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,8 @@ def fake_cli():
 
 
 @pytest.fixture
-def opts_from_fake_cli(fake_cli):
-    return JiraOptions(parser=fake_cli)
+def opts_from_fake_cli(fake_cli, fake_toml):
+    return JiraOptions(parser=fake_cli, toml_source=fake_toml)
 
 
 @pytest.fixture


### PR DESCRIPTION
When creating `fake_jira` fixture, we rely on `opts_from_fake_cli`. Due to the way `jira_options.py` also relies on the `toml` file, we should consider including it in the test setup.