### PR TITLE
Remove ignore field from Draft

### DIFF
--- a/mantis/drafts/__init__.py
+++ b/mantis/drafts/__init__.py
@@ -19,7 +19,7 @@ class Draft:
         self.issue = issue
         self.draft_path = self.jira.drafts_dir / f"{self.key}.md"
         self.summary = self.issue.get_field("summary", "")
-        assert self.required_frontmatter == ['ignore', 'header', 'project', 'parent', 'summary', 'status', 'issuetype', 'assignee', 'reporter']
+        assert self.required_frontmatter == ['header', 'project', 'parent', 'summary', 'status', 'issuetype', 'assignee', 'reporter']
         self._materialize()
 
     @property
@@ -92,7 +92,7 @@ class Draft:
         return draft_data
 
     def iter_draft_field_items(self) -> Generator[tuple[str, Any], None, None]:
-        local_vars = ('ignore', 'header')
+        local_vars = ('header')
         draft_data = self.read_draft()
         for draft_field_key in draft_data.keys():
             if draft_field_key in local_vars:  # E.g. Local custom fields
@@ -100,7 +100,7 @@ class Draft:
             yield draft_field_key, draft_data.get(draft_field_key)
 
     def iter_draft_field_keys(self) -> Generator[str, None, None]:
-        local_vars = ('ignore', 'header')
+        local_vars = ('header')
         draft_data = self.read_draft()
         for draft_field_key in draft_data.keys():
             if draft_field_key in local_vars:  # E.g. Local custom fields
@@ -108,6 +108,6 @@ class Draft:
             yield draft_field_key
 
     def get(self, key: str, default: Any = None) -> Any:
-        local_vars = ('ignore', 'header')
+        local_vars = ('header')
         draft_data = self.read_draft()
         return draft_data.get(key, default)

--- a/mantis/drafts/template.md
+++ b/mantis/drafts/template.md
@@ -1,5 +1,4 @@
 ---
-ignore: True
 header: "Will be set dynamically"
 project: {project}
 parent: {parent}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,6 @@ def minimal_issue_payload():
         "key": "TASK-1",
         "fields": {
             "summary": "redacted",
-            "ignore": True,
             "header": "redacted",
             "project": {"key": "redacted", "name": "redacted"},
             "parent": "redacted",

--- a/tests/data/drafts/ECS-1.md
+++ b/tests/data/drafts/ECS-1.md
@@ -1,7 +1,6 @@
 ---
 assignee: null
 header: '[ECS-1] (Sample) User Authentication'
-ignore: true
 issuetype: Epic
 parent: null
 project: E-Commerce Checkout System

--- a/tests/data/drafts/ECS-2.md
+++ b/tests/data/drafts/ECS-2.md
@@ -1,7 +1,6 @@
 ---
 assignee: null
 header: '[ECS-2] (Sample) Payment Processing'
-ignore: true
 issuetype: Epic
 parent: null
 project: E-Commerce Checkout System

--- a/tests/data/drafts/ECS-3.md
+++ b/tests/data/drafts/ECS-3.md
@@ -1,7 +1,6 @@
 ---
 assignee: null
 header: '[ECS-3] (Sample) Credit Card Payment Integration'
-ignore: true
 issuetype: Bug
 parent: ECS-2
 project: E-Commerce Checkout System

--- a/tests/data/drafts/ECS-4.md
+++ b/tests/data/drafts/ECS-4.md
@@ -1,7 +1,6 @@
 ---
 assignee: null
 header: '[ECS-4] (Sample) User Registration'
-ignore: true
 issuetype: Story
 parent: ECS-1
 project: E-Commerce Checkout System

--- a/tests/data/drafts/ECS-5.md
+++ b/tests/data/drafts/ECS-5.md
@@ -1,7 +1,6 @@
 ---
 assignee: null
 header: '[ECS-5] (Sample) Order Confirmation'
-ignore: true
 issuetype: Task
 parent: ECS-2
 project: E-Commerce Checkout System

--- a/tests/data/drafts/ECS-6.md
+++ b/tests/data/drafts/ECS-6.md
@@ -1,7 +1,6 @@
 ---
 assignee: null
 header: '[ECS-6] (Sample) User Login'
-ignore: true
 issuetype: Task
 parent:
   parent: null

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -34,7 +34,6 @@ class TestJiraDraft:
         expectations = (
             "---",
             "header: '[ECS-1] (Sample) User Authentication'",
-            "ignore: true",
             "parent: null",
             "summary: (Sample) User Authentication",
             "issuetype:",
@@ -64,7 +63,6 @@ class TestJiraDraft:
         assert set(draft_data.keys()) == {
             'assignee',
             'header',
-            'ignore',
             'issuetype',
             'parent',
             'project',


### PR DESCRIPTION
Initially included for testing purposes, we no longer need the `ignore` field in the `Draft` class. Removing all references.