### PR TITLE
Mark slow tests

### DIFF
--- a/tests/test_jira_config_loader.py
+++ b/tests/test_jira_config_loader.py
@@ -80,6 +80,7 @@ class TestConfigLoader:
         if not (fake_jira.cache.system / 'issuetypes.json').exists():
             raise FileNotFoundError('File "issuetypes.json" should have been created')
 
+    @pytest.mark.slow
     def test_update_createmeta(self, fake_jira: JiraClient, requests_mock):
         requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/TEST/issuetypes', json=CacheData().issuetypes)
         requests_mock.get(f'{fake_jira.api_url}/issue/createmeta/TEST/issuetypes/10001', json=CacheData().createmeta_epic)

--- a/tests/test_jira_inspector.py
+++ b/tests/test_jira_inspector.py
@@ -33,6 +33,7 @@ class TestInspector:
         with pytest.raises(ValueError):
             Inspector.print_table(["non-existent"], {"placeholder"}, issuetype_field_map)
 
+    @pytest.mark.slow
     def test_get_project_field_keys_from_cache(self, fake_jira: JiraClient):
         fake_jira.issues._allowed_types = ["Test"] # To avoid calling load_allowed_types
         with pytest.raises(CacheMissException):


### PR DESCRIPTION
Mark two tests as slow:
- `test_update_createmeta`
- `test_get_project_field_keys_from_cache`
