### PR TITLE
CI ensure version bump

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -82,6 +82,7 @@ jobs:
         poetry run mypy --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --explicit-package-bases mantis
 
   check-version-upgrade:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -80,3 +80,24 @@ jobs:
     - name: MyPy
       run: |
         poetry run mypy --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --explicit-package-bases mantis
+
+  check-version-upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch master branch
+        run: git fetch origin master:refs/remotes/origin/master
+      - name: Check version bump in pyproject.toml
+        run: |
+          set -e
+          VERSION_MASTER=$(git show origin/master:pyproject.toml | grep '^version' | head -1 | cut -d '"' -f2)
+          VERSION_HEAD=$(grep '^version' pyproject.toml | head -1 | cut -d '"' -f2)
+          echo "Master version: $VERSION_MASTER"
+          echo "Current version: $VERSION_HEAD"
+          if [ "$VERSION_MASTER" = "$VERSION_HEAD" ]; then
+            echo "Error: pyproject.toml version has not been updated!"
+            exit 1
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.1.0"
+version = "0.1.1"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}


### PR DESCRIPTION
Ensure that the package version in `pyproject.toml` has been updated in every PR.

If not updated, fail the check.

```sh
Master version: 0.1.0
Current version: 0.1.0
Error: pyproject.toml version has not been updated!
Error: Process completed with exit code 1.
```