### PR TITLE
Toml from xdg config

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1364,7 +1364,19 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[[package]]
+name = "xdg-base-dirs"
+version = "6.0.2"
+description = "Variables defined by the XDG Base Directory Specification"
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "xdg_base_dirs-6.0.2-py3-none-any.whl", hash = "sha256:3c01d1b758ed4ace150ac960ac0bd13ce4542b9e2cdf01312dcda5012cfebabe"},
+    {file = "xdg_base_dirs-6.0.2.tar.gz", hash = "sha256:950504e14d27cf3c9cb37744680a43bf0ac42efefc4ef4acf98dc736cab2bced"},
+]
+
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12"
-content-hash = "ade8c2010ca3f897aa9f59477f294e6ceed8a4cfa300b024c97443e339c64cb0"
+python-versions = "<4.0,>=3.12"
+content-hash = "95d9df3b8302946020e2c2aaececf67e659e2144fcb8d1c0038f62809e496f6e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = { file = "LICENSE.md" }
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = "<4.0,>=3.12"
 dependencies = [
     "pytest (>=8.4.0,<9.0.0)",
     "requests (>=2.32.4,<3.0.0)",
@@ -21,7 +21,8 @@ dependencies = [
     "mypy (>=1.16.0,<2.0.0)",
     "flake8 (>=7.2.0,<8.0.0)",
     "python-frontmatter (>=1.1.0,<2.0.0)",
-    "openai (>=1.86.0,<2.0.0)"
+    "openai (>=1.86.0,<2.0.0)",
+    "xdg-base-dirs (>=6.0.2,<7.0.0)"
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.2.1"
+version = "0.2.2"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from mantis.mantis_client import MantisClient
 from mantis.options_loader import OptionsLoader, parse_args
 
 def main() -> None:
-    options = OptionsLoader(parse_args(), 'mantis.toml')
+    options = OptionsLoader(parse_args())
     mantis = MantisClient(options)
     jira = mantis.jira
 

--- a/src/mantis/cache.py
+++ b/src/mantis/cache.py
@@ -37,7 +37,7 @@ class Cache:
 
     @property
     def root(self) -> Path:
-        return Path(self.mantis.options.cache_dir)
+        return Path(self.mantis.cache_dir)
 
     @property
     def issues(self) -> Path:

--- a/src/mantis/http.py
+++ b/src/mantis/http.py
@@ -11,7 +11,7 @@ class Http:
     A class to handle HTTP requests and responses.
     """
 
-    def __init__(self, mantis: 'MantisClient', no_read_cache: bool = False):
+    def __init__(self, mantis: 'MantisClient', no_read_cache: bool = False) -> None:
         self.mantis = mantis
         self.options = mantis.options
 

--- a/src/mantis/jira/jira_auth.py
+++ b/src/mantis/jira/jira_auth.py
@@ -17,10 +17,14 @@ class JiraAuth:
 
     @property
     def user(self) -> str:
+        if not self.options.user:
+            raise PermissionError('User must be set in options')
         return self.options.user
 
     @property
     def personal_access_token(self) -> str:
+        if not self.options.personal_access_token:
+            raise PermissionError('Personal access token must be set in options')
         return self.options.personal_access_token
 
     @property

--- a/src/mantis/jira/jira_client.py
+++ b/src/mantis/jira/jira_client.py
@@ -46,6 +46,8 @@ class JiraClient:
 
     @property
     def project_name(self) -> str:
+        if not self.mantis.options.project:
+            raise ValueError('Project name must be set in options')
         return self.mantis.options.project
     
     @property

--- a/src/mantis/mantis_client.py
+++ b/src/mantis/mantis_client.py
@@ -12,6 +12,7 @@ class MantisClient:
     def __init__(self, options: "OptionsLoader", no_read_cache: bool = False):
         self.options = options
         self._no_read_cache = no_read_cache
+        self.cache_dir.mkdir(exist_ok=True)
         self.drafts_dir.mkdir(exist_ok=True)
         self.plugins_dir.mkdir(exist_ok=True)
         self.cache = Cache(self)
@@ -27,3 +28,7 @@ class MantisClient:
     @property
     def plugins_dir(self) -> Path:
         return Path(self.options.plugins_dir)
+
+    @property
+    def cache_dir(self) -> Path:
+        return Path(self.options.cache_dir)

--- a/src/mantis/mantis_client.py
+++ b/src/mantis/mantis_client.py
@@ -14,8 +14,6 @@ class MantisClient:
         self._no_read_cache = no_read_cache
         self.drafts_dir.mkdir(exist_ok=True)
         self.plugins_dir.mkdir(exist_ok=True)
-        self.drafts_dir.mkdir(exist_ok=True)
-        self.plugins_dir.mkdir(exist_ok=True)
         self.cache = Cache(self)
         self.jira = JiraClient(self)
         self.http = Http(self, no_read_cache)

--- a/src/mantis/mantis_client.py
+++ b/src/mantis/mantis_client.py
@@ -9,7 +9,7 @@ from mantis.options_loader import OptionsLoader
 
 class MantisClient:
 
-    def __init__(self, options: "OptionsLoader", no_read_cache: bool = False):
+    def __init__(self, options: "OptionsLoader", no_read_cache: bool = False) -> None:
         self.options = options
         self._no_read_cache = no_read_cache
         self.cache_dir.mkdir(exist_ok=True)

--- a/src/mantis/options_loader.py
+++ b/src/mantis/options_loader.py
@@ -1,5 +1,8 @@
 import argparse
+from pathlib import Path
 import tomllib
+
+from xdg_base_dirs import xdg_config_home
 
 
 MANTIS_TOML = "mantis.toml"
@@ -7,7 +10,26 @@ MANTIS_TOML = "mantis.toml"
 
 class OptionsLoader:
     """Collects options from toml file, allowing for command line overrides"""
+    
+    def load_toml(self, toml_path: Path) -> dict:
+        """Load options from a TOML file."""
+        if not toml_path.is_file():
+            return {}
+        try:
+            with open(toml_path, "rb") as f:
+                return tomllib.load(f)
+        except Exception as e:
+            print(f"Error loading {toml_path}: {e}")
+            return {}
 
+    def default_toml(self):
+        """Get the mantis directory under either XDG config home or user home"""
+        config_home = xdg_config_home()
+        return self.load_toml(config_home / MANTIS_TOML)
+
+    def cwd_toml(self):
+        """Get the mantis directory under either XDG config home or user home"""
+        return self.load_toml(Path.cwd() / MANTIS_TOML)
 
     def __init__(
         self,

--- a/src/mantis/options_loader.py
+++ b/src/mantis/options_loader.py
@@ -49,7 +49,8 @@ class OptionsLoader:
     @property
     def user(self) -> str:
         val = self.parser and self.parser.user or self.options.get("jira", {}).get("user")
-        assert val, "OptionsLoader.user not set"
+        if not val:
+            raise ValueError('OptionsLoader.user not set')
         return val
 
     @property
@@ -67,7 +68,8 @@ class OptionsLoader:
     @property
     def project(self) -> str:
         val = self.parser and self.parser.project or self.options.get("jira", {}).get("project")
-        assert val, "OptionsLoader.project not set"
+        if not val:
+            raise ValueError('OptionsLoader.project not set')
         return val
 
     @property
@@ -81,7 +83,8 @@ class OptionsLoader:
     @property
     def cache_dir(self) -> str:
         val = self.parser and self.parser.cache_dir or self.options.get("jira", {}).get("cache-dir")
-        assert val, "OptionsLoader.cache_dir not set"
+        if not val:
+            raise ValueError('OptionsLoader.cache_dir not set')
         return val
         
     @cache_dir.setter
@@ -94,7 +97,8 @@ class OptionsLoader:
     @property
     def drafts_dir(self) -> str:
         val = self.parser and self.parser.drafts_dir or self.options.get("jira", {}).get("drafts-dir")
-        assert val, "OptionsLoader.drafts_dir not set"
+        if not val:
+            raise ValueError('OptionsLoader.drafts_dir not set')
         return val
 
     @drafts_dir.setter
@@ -107,7 +111,8 @@ class OptionsLoader:
     @property
     def plugins_dir(self) -> str:
         val = self.parser and self.parser.plugins_dir or self.options.get("jira", {}).get("plugins-dir")
-        assert val, "OptionsLoader.plugins_dir not set"
+        if not val:
+            raise ValueError('OptionsLoader.plugins_dir not set')
         return val
 
     @plugins_dir.setter

--- a/src/mantis/options_loader.py
+++ b/src/mantis/options_loader.py
@@ -2,11 +2,12 @@ import argparse
 import tomllib
 
 
-class OptionsLoader:
-    """Collects options from toml file, allowing for command line overrides
-    """
+MANTIS_TOML = "mantis.toml"
 
-    default_toml_source = "mantis.toml"
+
+class OptionsLoader:
+    """Collects options from toml file, allowing for command line overrides"""
+
 
     def __init__(
         self,
@@ -14,7 +15,7 @@ class OptionsLoader:
         toml_source: str | None = None,
     ):
         if not toml_source:
-            toml_source = self.default_toml_source
+            toml_source = MANTIS_TOML
         try:
             with open(toml_source, "rb") as f:
                 options = tomllib.load(f)

--- a/src/mantis/options_loader.py
+++ b/src/mantis/options_loader.py
@@ -10,7 +10,7 @@ MANTIS_TOML = "mantis.toml"
 
 class OptionsLoader:
     """Collects options from toml file, allowing for command line overrides"""
-    def __init__(self, parser: "argparse.Namespace | None" = None):
+    def __init__(self, parser: "argparse.Namespace | None" = None) -> None:
         self.options = {}
         self.options.update(self.default_toml())
         self.options.update(self.cwd_toml())
@@ -24,16 +24,16 @@ class OptionsLoader:
         with open(toml_path, "rb") as f:
             return tomllib.load(f)
 
-    def default_toml(self):
+    def default_toml(self) -> dict:
         """Get the mantis directory under either XDG config home or user home"""
         config_home = xdg_config_home()
         return self.load_toml(config_home / MANTIS_TOML)
 
-    def cwd_toml(self):
+    def cwd_toml(self) -> dict:
         """Get the mantis directory under either XDG config home or user home"""
         return self.load_toml(Path.cwd() / MANTIS_TOML)
 
-    def sanity_check(self):
+    def sanity_check(self) -> None:
         """Check that all required options are set."""
         assert self.user, "OptionsLoader.user not set"
         assert self.personal_access_token, "OptionsLoader.personal_access_token not set"
@@ -47,11 +47,13 @@ class OptionsLoader:
             assert self.chat_gpt_api_key, f"ChatGPT is activated, but OptionsLoader.chat_gpt_api_key not set {self.options}"
 
     @property
-    def user(self):
-        return self.parser and self.parser.user or self.options.get("jira", {}).get("user")
+    def user(self) -> str:
+        val = self.parser and self.parser.user or self.options.get("jira", {}).get("user")
+        assert val, "OptionsLoader.user not set"
+        return val
 
     @property
-    def personal_access_token(self):
+    def personal_access_token(self) -> str | None:
         return (
             self.parser
             and self.parser.personal_access_token
@@ -59,17 +61,17 @@ class OptionsLoader:
         )
 
     @property
-    def url(self):
+    def url(self) -> str | None:
         return self.parser and self.parser.url or self.options.get("jira", {}).get("url")
 
     @property
-    def project(self):
-        return (
-            self.parser and self.parser.project or self.options.get("jira", {}).get("project")
-        )
+    def project(self) -> str:
+        val = self.parser and self.parser.project or self.options.get("jira", {}).get("project")
+        assert val, "OptionsLoader.project not set"
+        return val
 
     @property
-    def no_verify_ssl(self):
+    def no_verify_ssl(self) -> bool:
         return bool(
             self.parser
             and self.parser.no_verify_ssl
@@ -77,46 +79,46 @@ class OptionsLoader:
         )
 
     @property
-    def cache_dir(self):
-        return (
-            self.parser and self.parser.cache_dir or self.options.get("jira", {}).get("cache-dir")
-        )
+    def cache_dir(self) -> str:
+        val = self.parser and self.parser.cache_dir or self.options.get("jira", {}).get("cache-dir")
+        assert val, "OptionsLoader.cache_dir not set"
+        return val
         
     @cache_dir.setter
-    def cache_dir(self, value):
+    def cache_dir(self, value: str) -> None:
         if self.parser:
             self.parser.cache_dir = value
         else:
             self.options["jira"]["cache-dir"] = value
 
     @property
-    def drafts_dir(self):
-        return (
-            self.parser and self.parser.drafts_dir or self.options.get("jira", {}).get("drafts-dir")
-        )
+    def drafts_dir(self) -> str:
+        val = self.parser and self.parser.drafts_dir or self.options.get("jira", {}).get("drafts-dir")
+        assert val, "OptionsLoader.drafts_dir not set"
+        return val
 
     @drafts_dir.setter
-    def drafts_dir(self, value):
+    def drafts_dir(self, value: str) -> None:
         if self.parser:
             self.parser.drafts_dir = value
         else:
             self.options["jira"]["drafts-dir"] = value
 
     @property
-    def plugins_dir(self):
-        return (
-            self.parser and self.parser.plugins_dir or self.options.get("jira", {}).get("plugins-dir")
-        )
+    def plugins_dir(self) -> str:
+        val = self.parser and self.parser.plugins_dir or self.options.get("jira", {}).get("plugins-dir")
+        assert val, "OptionsLoader.plugins_dir not set"
+        return val
 
     @plugins_dir.setter
-    def plugins_dir(self, value):
+    def plugins_dir(self, value: str) -> None:
         if self.parser:
             self.parser.plugins_dir = value
         else:
             self.options["jira"]["plugins-dir"] = value
 
     @property
-    def type_id_cutoff(self):
+    def type_id_cutoff(self) -> int:
         return int(
             self.parser
             and self.parser.type_id_cutoff
@@ -125,7 +127,7 @@ class OptionsLoader:
 
 
     @property
-    def chat_gpt_base_url(self):
+    def chat_gpt_base_url(self) -> str | None:
         return (
             self.parser
             and self.parser.chat_gpt_base_url
@@ -133,7 +135,7 @@ class OptionsLoader:
         )
 
     @property
-    def chat_gpt_api_key(self):
+    def chat_gpt_api_key(self) -> str | None:
         return (
             self.parser
             and self.parser.chat_gpt_api_key
@@ -141,7 +143,7 @@ class OptionsLoader:
         )
 
     @property
-    def chat_gpt_activated(self):
+    def chat_gpt_activated(self) -> bool:
         return bool(
             # Since a bool can be False, we can't rely on the truthiness of the value and use "or" like in the other cases.
             self.parser.chat_gpt_activated if self.parser and isinstance(self.parser.chat_gpt_activated, bool)
@@ -149,7 +151,7 @@ class OptionsLoader:
         )
 
     @property
-    def action(self):
+    def action(self) -> str:
         return self.parser and self.parser.action or ""
 
     @property

--- a/src/mantis/options_loader.py
+++ b/src/mantis/options_loader.py
@@ -15,12 +15,8 @@ class OptionsLoader:
         """Load options from a TOML file."""
         if not toml_path.is_file():
             return {}
-        try:
-            with open(toml_path, "rb") as f:
-                return tomllib.load(f)
-        except Exception as e:
-            print(f"Error loading {toml_path}: {e}")
-            return {}
+        with open(toml_path, "rb") as f:
+            return tomllib.load(f)
 
     def default_toml(self):
         """Get the mantis directory under either XDG config home or user home"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,12 +80,6 @@ def opts_from_fake_cli(fake_cli):
 
 
 @pytest.fixture
-def jira_client_from_fake_cli(opts_from_fake_cli):
-    mantis = MantisClient(opts_from_fake_cli)
-    return mantis.jira
-
-
-@pytest.fixture
 def with_no_read_cache(fake_jira: JiraClient):
     fake_jira.mantis._no_read_cache = True
 
@@ -133,11 +127,11 @@ def fake_jira(
     with_fake_drafts_dir,
     with_fake_plugins_dir,
     patch_load_toml,
-    jira_client_from_fake_cli,
+    opts_from_fake_cli,
     minimal_issue_payload,
 ):
-    jira = jira_client_from_fake_cli
-    assert str(jira.mantis.cache.root) != ".jira_cache_test"
-    assert str(jira.mantis.drafts_dir) != "drafts_test"
-    assert str(jira.mantis.plugins_dir) != "plugins_test"
-    return jira
+    mantis = MantisClient(opts_from_fake_cli)
+    assert str(mantis.jira.mantis.cache.root) != ".jira_cache_test"
+    assert str(mantis.jira.mantis.drafts_dir) != "drafts_test"
+    assert str(mantis.jira.mantis.plugins_dir) != "plugins_test"
+    return mantis.jira

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,7 @@ def minimal_issue_payload():
         }
     }
 
+# The execution order is determined by the fixture dependency graph, not by the order in the file or the order in the function signature. Pytest always sets up dependencies first, from the leaves up to the fixture requested by the test.
 @pytest.fixture
 def fake_jira(
     with_fake_cache,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,24 +8,6 @@ from mantis.mantis_client import MantisClient
 from mantis.options_loader import OptionsLoader
 
 
-@dataclass
-class Cli:
-    user = "user_1@domain.com"
-    url = "https://account_1.atlassian-host.net"
-    personal_access_token = "SECRET_1"
-    project = "TEST"
-    no_verify_ssl = False
-    cache_dir = ".jira_cache_test"
-    drafts_dir = "drafts_test"
-    plugins_dir = "plugins_test"
-    type_id_cutoff = "10100"
-    action = ""
-    issues = [""]
-    chat_gpt_activated = False
-    chat_gpt_base_url = "https://api.fakeai.com/v1"
-    chat_gpt_api_key = "socks_off_full_throttle_$%^"
-
-
 @pytest.fixture
 def fake_toml(tmpdir):
     toml_contents = "\n".join(
@@ -52,8 +34,27 @@ def fake_toml(tmpdir):
     return toml
 
 
+@dataclass
+class Cli:
+    user = "user_1@domain.com"
+    url = "https://account_1.atlassian-host.net"
+    personal_access_token = "SECRET_1"
+    project = "TEST"
+    no_verify_ssl = False
+    cache_dir = ".jira_cache_test"
+    drafts_dir = "drafts_test"
+    plugins_dir = "plugins_test"
+    type_id_cutoff = "10100"
+    action = ""
+    issues = [""]
+    chat_gpt_activated = False
+    chat_gpt_base_url = "https://api.fakeai.com/v1"
+    chat_gpt_api_key = "socks_off_full_throttle_$%^"
+
+
 @pytest.fixture
 def fake_cli():
+    """Create a fake CLI object with default values for testing option overrides"""
     return Cli()
 
 

--- a/tests/test_jira_auth.py
+++ b/tests/test_jira_auth.py
@@ -6,7 +6,7 @@ from mantis.options_loader import OptionsLoader
 
 
 class TestJiraAuth:
-    def test_creates_jira_auth_settings(self):
+    def test_creates_jira_auth_settings(self, patch_load_toml):
         opts = OptionsLoader()
         auth = JiraAuth(opts)
         assert isinstance(auth.auth, HTTPBasicAuth)

--- a/tests/test_jira_auth.py
+++ b/tests/test_jira_auth.py
@@ -6,8 +6,8 @@ from mantis.options_loader import OptionsLoader
 
 
 class TestJiraAuth:
-    def test_creates_jira_auth_settings(self, fake_toml):
-        opts = OptionsLoader(toml_source=fake_toml)
+    def test_creates_jira_auth_settings(self):
+        opts = OptionsLoader()
         auth = JiraAuth(opts)
         assert isinstance(auth.auth, HTTPBasicAuth)
 

--- a/tests/test_jira_options.py
+++ b/tests/test_jira_options.py
@@ -24,7 +24,7 @@ class TestJiraOptions:
     def test_options_not_set(self, tmpdir, patch_load_toml, capfd):
         toml = tmpdir / "mantis.toml"
         toml.write("")
-        with pytest.raises(AssertionError) as execution_error:
+        with pytest.raises(ValueError) as execution_error:
             OptionsLoader()
         assert str(execution_error.value) == "OptionsLoader.user not set"
         out, err = capfd.readouterr()

--- a/tests/test_jira_options.py
+++ b/tests/test_jira_options.py
@@ -6,34 +6,30 @@ from mantis.options_loader import OptionsLoader, parse_args
 
 
 class TestJiraOptions:
-    def test_options(self, fake_toml):
-        opts = OptionsLoader(toml_source=fake_toml)
+    def test_options(self, patch_load_toml):
+        opts = OptionsLoader()
         assert opts.user == "user_2@domain.com"
         assert opts.url == "https://account_2.atlassian-host.net"
         assert opts.personal_access_token == "SECRET_2"
         assert opts.chat_gpt_base_url == 'https://api.fakeai.com/v1'
 
 
-    def test_options_override(self, fake_toml, fake_cli):
-        opts = OptionsLoader(toml_source=fake_toml, parser=fake_cli)
+    def test_options_override(self, fake_cli):
+        opts = OptionsLoader(parser=fake_cli)
         assert opts.user == "user_1@domain.com"
         assert opts.url == "https://account_1.atlassian-host.net"
         assert opts.personal_access_token == "SECRET_1"
 
 
-    def test_options_not_set(self, tmpdir, capfd):
+    def test_options_not_set(self, tmpdir, patch_load_toml, capfd):
         toml = tmpdir / "mantis.toml"
-        with pytest.raises(AssertionError):
-            OptionsLoader(toml_source=toml)
-        out, _ = capfd.readouterr()
-        assert out == 'No toml_source provided and default "mantis.toml" does not exist\n'
         toml.write("")
         with pytest.raises(AssertionError) as execution_error:
-            OptionsLoader(toml_source=toml)
+            OptionsLoader()
+        assert str(execution_error.value) == "OptionsLoader.user not set"
         out, err = capfd.readouterr()
         assert out == ""
         assert err == ""
-        assert str(execution_error.value) == "OptionsLoader.user not set"
 
     def test_parse_args_issues(self):
         # We need to pass an empty list. If we didn't, pytest would default


### PR DESCRIPTION
To prepare for end-user distribution, allow `OptionLoader` to read `mantis.toml` from `XDG_CONFIG_HOME` / `$HOME/.config` with local overwrites in current working directory.