### PR TITLE
Tests operate on fake_mantis not fake_jira

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.2.2"
+version = "0.2.3"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 from unittest.mock import patch
 
-from mantis.jira import JiraClient
 from mantis.mantis_client import MantisClient
 from mantis.options_loader import OptionsLoader
 
@@ -80,8 +79,8 @@ def opts_from_fake_cli(fake_cli):
 
 
 @pytest.fixture
-def with_no_read_cache(fake_jira: JiraClient):
-    fake_jira.mantis._no_read_cache = True
+def with_no_read_cache(fake_mantis: MantisClient):
+    fake_mantis._no_read_cache = True
 
 
 @pytest.fixture
@@ -122,7 +121,7 @@ def minimal_issue_payload():
 
 # The execution order is determined by the fixture dependency graph, not by the order in the file or the order in the function signature. Pytest always sets up dependencies first, from the leaves up to the fixture requested by the test.
 @pytest.fixture
-def fake_jira(
+def fake_mantis(
     with_fake_cache,
     with_fake_drafts_dir,
     with_fake_plugins_dir,
@@ -134,4 +133,4 @@ def fake_jira(
     assert str(mantis.jira.mantis.cache.root) != ".jira_cache_test"
     assert str(mantis.jira.mantis.drafts_dir) != "drafts_test"
     assert str(mantis.jira.mantis.plugins_dir) != "plugins_test"
-    return mantis.jira
+    return mantis

--- a/tests/test_jira_autocomplete.py
+++ b/tests/test_jira_autocomplete.py
@@ -1,12 +1,12 @@
-from mantis.jira.jira_client import JiraClient
+from mantis.mantis_client import MantisClient
 from tests.data import CacheData
 
 
 class TestJiraAutocomplete:
-    def test_get_suggestions(self, fake_jira: JiraClient, requests_mock):
+    def test_get_suggestions(self, fake_mantis: MantisClient, requests_mock):
         accountId = CacheData().placeholder_account['accountId']
         return_value = {'results': [{'value': accountId, 'displayName': '<b>Marcus</b> Aurelius - <b>marcus</b>@rome.gov'}]}
-        requests_mock.get(fake_jira.mantis.http.api_url + '/jql/autocompletedata/suggestions?fieldName=reporter&fieldValue=Marcus', json=return_value)
-        suggestions = fake_jira.auto_complete.get_suggestions('reporter', 'Marcus')
+        requests_mock.get(fake_mantis.http.api_url + '/jql/autocompletedata/suggestions?fieldName=reporter&fieldValue=Marcus', json=return_value)
+        suggestions = fake_mantis.jira.auto_complete.get_suggestions('reporter', 'Marcus')
         assert len(suggestions) == 1
         assert suggestions[0].display_name == 'Marcus Aurelius - marcus@rome.gov'

--- a/tests/test_jira_cache.py
+++ b/tests/test_jira_cache.py
@@ -1,86 +1,86 @@
 import json
 import pytest
 
-from mantis.jira import JiraClient
+from mantis.mantis_client import MantisClient
 from tests.data import CacheData, get_issuetypes_response
 
 
 class TestCache:
     @pytest.fixture(autouse=True)
-    def _request_jira(self, fake_jira: JiraClient):
-        self.jira = fake_jira
+    def _request_jira(self, fake_mantis: MantisClient):
+        self.mantis = fake_mantis
 
     @pytest.fixture(autouse=True)
     def _request_minimal_issue_payload(self, minimal_issue_payload: dict):
         self.issue_payload = minimal_issue_payload
 
     def test_cache_get_caches_jira_issue(self):
-        assert not self.jira.mantis._no_read_cache
-        assert self.jira.mantis.cache._get(self.jira.mantis.cache.issues, "TASK-1.json") is None
+        assert not self.mantis._no_read_cache
+        assert self.mantis.cache._get(self.mantis.cache.issues, "TASK-1.json") is None
 
-        with open(self.jira.mantis.cache.root / "issues/TASK-1.json", "w") as f:
+        with open(self.mantis.cache.root / "issues/TASK-1.json", "w") as f:
             json.dump(self.issue_payload, f)
 
-        decoded = self.jira.mantis.cache._get(self.jira.mantis.cache.issues, "TASK-1.json")
+        decoded = self.mantis.cache._get(self.mantis.cache.issues, "TASK-1.json")
         assert decoded
         assert decoded.get("key", '') == "TASK-1"
 
     def test_cache_get_issue_returns_none_when_no_read_cache_is_set(self):
         # Make sure nothing is cached
-        assert not self.jira.mantis._no_read_cache
-        assert self.jira.mantis.cache.get_issue("TASK-1") is None
+        assert not self.mantis._no_read_cache
+        assert self.mantis.cache.get_issue("TASK-1") is None
 
         # cache something
-        with open(self.jira.mantis.cache.root / "issues/TASK-1.json", "w") as f:
+        with open(self.mantis.cache.root / "issues/TASK-1.json", "w") as f:
             json.dump(self.issue_payload, f)
-        something = self.jira.mantis.cache.get_issue("TASK-1")
+        something = self.mantis.cache.get_issue("TASK-1")
         assert something is not None
 
         # Deactivate the cache and make sure nothing is retrieved
-        self.jira.mantis._no_read_cache = True
+        self.mantis._no_read_cache = True
         with pytest.raises(LookupError):
-            nothing_2 = self.jira.mantis.cache.get_issue("TASK-1")
+            nothing_2 = self.mantis.cache.get_issue("TASK-1")
             assert nothing_2 is None
 
     def test_cache_remove_does_removals(self):
         # cache something
-        with open(self.jira.mantis.cache.root / "issues/TASK-1.json", "w") as f:
+        with open(self.mantis.cache.root / "issues/TASK-1.json", "w") as f:
             json.dump(self.issue_payload, f)
-        something_1 = self.jira.mantis.cache.get_issue("TASK-1")
+        something_1 = self.mantis.cache.get_issue("TASK-1")
         assert something_1 is not None
 
         # remove with cache.remove
-        assert self.jira.mantis.cache.remove("issues/TASK-1.json")
-        assert not self.jira.mantis.cache.remove("issues/TASK-1.json")
-        nothing_1 = self.jira.mantis.cache.get_issue("TASK-1")
+        assert self.mantis.cache.remove("issues/TASK-1.json")
+        assert not self.mantis.cache.remove("issues/TASK-1.json")
+        nothing_1 = self.mantis.cache.get_issue("TASK-1")
         assert nothing_1 is None
 
     def test_cache_remove_issue_does_removals(self):
         # cache something
-        with open(self.jira.mantis.cache.root / "issues/TASK-1.json", "w") as f:
+        with open(self.mantis.cache.root / "issues/TASK-1.json", "w") as f:
             json.dump(self.issue_payload, f)
-        something_2 = self.jira.mantis.cache.get_issue("TASK-1")
+        something_2 = self.mantis.cache.get_issue("TASK-1")
         assert something_2 is not None
 
         # remove with cache.remove_issue
-        self.jira.mantis.cache.remove_issue("TASK-1")
-        nothing_2 = self.jira.mantis.cache.get_issue("TASK-1")
+        self.mantis.cache.remove_issue("TASK-1")
+        nothing_2 = self.mantis.cache.get_issue("TASK-1")
         assert nothing_2 is None
 
     @pytest.mark.parametrize("identifier", [("createmeta")])
     def test_cache_iter_dir_yields_files(self, identifier: str):
-        assert len(list(self.jira.mantis.cache.iter_dir(identifier))) == 0
+        assert len(list(self.mantis.cache.iter_dir(identifier))) == 0
         # cache something
-        with open(self.jira.mantis.cache.system / f"{identifier}/some_file.json", "w") as f:
+        with open(self.mantis.cache.system / f"{identifier}/some_file.json", "w") as f:
             f.write("{}")
-        assert len(list(self.jira.mantis.cache.iter_dir(identifier))) == 1
+        assert len(list(self.mantis.cache.iter_dir(identifier))) == 1
 
     def test_cache_get_issuetypes_from_system_cache(self, requests_mock):
-        requests_mock.get(f'{self.jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=get_issuetypes_response)
+        requests_mock.get(f'{self.mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=get_issuetypes_response)
 
-        with open(self.jira.mantis.cache.system / "issuetypes.json", "w") as f:
+        with open(self.mantis.cache.system / "issuetypes.json", "w") as f:
             json.dump(CacheData().issuetypes, f)
-        retrieved = self.jira.mantis.cache.get_issuetypes_from_system_cache()
+        retrieved = self.mantis.cache.get_issuetypes_from_system_cache()
         assert retrieved
         assert len(retrieved['issueTypes']) == 5
         subtask = [_type for _type in retrieved['issueTypes'] if _type['name'] == 'Subtask'][0]

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -3,69 +3,68 @@ import requests
 
 from unittest.mock import patch
 
-from mantis.jira import JiraClient
-from mantis.jira.auto_complete import Suggestion
+from mantis.mantis_client import MantisClient
 from tests.data import CacheData
 
 
 class TestJiraClient:
-    def test_test_auth_complains_with_bad_input(self, requests_mock, fake_jira: JiraClient, capsys):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/myself', json={})
-        fake_jira.test_auth()
+    def test_test_auth_complains_with_bad_input(self, requests_mock, fake_mantis: MantisClient, capsys):
+        requests_mock.get(f'{fake_mantis.http.api_url}/myself', json={})
+        fake_mantis.jira.test_auth()
         captured = capsys.readouterr()
         assert captured.out == ("Connected as user: ERROR: No displayName\n")
         assert captured.err == ""
 
-    def test_test_auth_informs_login(self, requests_mock, fake_jira: JiraClient, capsys):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/myself', json={'displayName': 'Buddy'})
-        fake_jira.test_auth()
+    def test_test_auth_informs_login(self, requests_mock, fake_mantis: MantisClient, capsys):
+        requests_mock.get(f'{fake_mantis.http.api_url}/myself', json={'displayName': 'Buddy'})
+        fake_mantis.jira.test_auth()
         captured = capsys.readouterr()
         assert captured.out == ("Connected as user: Buddy\n")
         assert captured.err == ""
 
-    def test_cache_exists(self, fake_jira: JiraClient):
-        assert str(fake_jira.mantis.cache.root) != ".jira_cache_test"
-        list_of = [str(_).split('/')[-1] for _ in fake_jira.mantis.cache.root.iterdir()]
-        assert len(list(fake_jira.mantis.cache.root.iterdir())) == 2, f'Iter root expected two values, got: {list_of}'
-        assert {item.name for item in fake_jira.mantis.cache.root.iterdir()} == {"system", "issues"}
-        assert len(list(fake_jira.mantis.cache.system.iterdir())) == 4
-        assert {item.name for item in fake_jira.mantis.cache.system.iterdir()} == {"createmeta", 'createmeta_schemas', "editmeta", 'editmeta_schemas'}
+    def test_cache_exists(self, fake_mantis: MantisClient):
+        assert str(fake_mantis.cache.root) != ".jira_cache_test"
+        list_of = [str(_).split('/')[-1] for _ in fake_mantis.cache.root.iterdir()]
+        assert len(list(fake_mantis.cache.root.iterdir())) == 2, f'Iter root expected two values, got: {list_of}'
+        assert {item.name for item in fake_mantis.cache.root.iterdir()} == {"system", "issues"}
+        assert len(list(fake_mantis.cache.system.iterdir())) == 4
+        assert {item.name for item in fake_mantis.cache.system.iterdir()} == {"createmeta", 'createmeta_schemas', "editmeta", 'editmeta_schemas'}
 
-    def test_get_current_user(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/myself', json=CacheData().placeholder_account)
-        assert fake_jira.get_current_user() == {
+    def test_get_current_user(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/myself', json=CacheData().placeholder_account)
+        assert fake_mantis.jira.get_current_user() == {
             "accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz",
             "emailAddress": "marcus@rome.gov",
             "displayName": "Marcus Aurelius",
         }
 
-    def test_get_current_user_account_id(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/myself', json=CacheData().placeholder_account)
+    def test_get_current_user_account_id(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/myself', json=CacheData().placeholder_account)
         assert (
-            fake_jira.get_current_user_account_id()
+            fake_mantis.jira.get_current_user_account_id()
             == "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"
         )
 
-    def test_get_current_user_as_assignee(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/myself', json=CacheData().placeholder_account)
-        assert fake_jira.get_current_user_as_assignee() == {
+    def test_get_current_user_as_assignee(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/myself', json=CacheData().placeholder_account)
+        assert fake_mantis.jira.get_current_user_as_assignee() == {
             "assignee": {"accountId": "492581:638245r0-3d02-ki30-kchs-3kjd92hafjmz"}
         }
 
-    def test_get_test_auth_success(self, fake_jira: JiraClient, capsys, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/myself', json=CacheData().placeholder_account)
-        assert fake_jira.test_auth()
+    def test_get_test_auth_success(self, fake_mantis: MantisClient, capsys, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/myself', json=CacheData().placeholder_account)
+        assert fake_mantis.jira.test_auth()
         captured = capsys.readouterr()
         assert captured.out == "Connected as user: Marcus Aurelius\n"
         assert captured.err == ""
 
-    def test_get_test_auth_connection_error(self, fake_jira: JiraClient, capsys):
+    def test_get_test_auth_connection_error(self, fake_mantis: MantisClient, capsys):
         with patch(
             "mantis.jira.jira_client.requests.get",
             side_effect=requests.exceptions.ConnectionError,
         ):
             with pytest.raises(SystemExit) as pytest_wrapped_e:
-                fake_jira.test_auth()
+                fake_mantis.jira.test_auth()
             assert pytest_wrapped_e.type == SystemExit
             assert pytest_wrapped_e.value.code == 1
         captured = capsys.readouterr()
@@ -76,43 +75,43 @@ class TestJiraClient:
         )
         assert captured.err == ""
 
-    def test_get_test_auth_generic_exception(self, fake_jira: JiraClient, capsys):
+    def test_get_test_auth_generic_exception(self, fake_mantis: MantisClient, capsys):
         with patch(
             "mantis.jira.jira_client.requests.get",
             side_effect=requests.exceptions.RequestException,
         ):
             with pytest.raises(requests.exceptions.RequestException):
-                fake_jira.test_auth()
+                fake_mantis.jira.test_auth()
         captured = capsys.readouterr()
         assert captured.out == ("test_auth failed for unknown reasons.\n")
         assert captured.err == ""
 
-    def test_jql_auto_complete_returns_json(self, fake_jira: JiraClient, requests_mock):
-        url = f'{fake_jira.mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=reporter&fieldValue=Marcus'
+    def test_jql_auto_complete_returns_json(self, fake_mantis: MantisClient, requests_mock):
+        url = f'{fake_mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=reporter&fieldValue=Marcus'
         accountId = CacheData().placeholder_account['accountId']
         return_value = {'results': [{'value': accountId, 'displayName': '<b>Marcus</b> Aurelius - <b>marcus</b>@rome.gov'}]}
         requests_mock.get(url, json=return_value)
-        raw_auto_complete = fake_jira.jql_auto_complete('reporter', 'Marcus')
+        raw_auto_complete = fake_mantis.jira.jql_auto_complete('reporter', 'Marcus')
         assert raw_auto_complete == return_value
 
-    def test_validate_input_returns_one_suggestion(self, fake_jira: JiraClient, requests_mock, capsys):
-        url = f'{fake_jira.mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=cf[10001]&fieldValue=Commerce'
+    def test_validate_input_returns_one_suggestion(self, fake_mantis: MantisClient, requests_mock, capsys):
+        url = f'{fake_mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=cf[10001]&fieldValue=Commerce'
         entry = {'value': 'abc123', 'displayName': 'E-<b>Commerce</b> Checkout Team'}
         return_value = {'results': [entry]}
         requests_mock.get(url, json=return_value)
-        validation_suggestions = fake_jira.validate_input('cf[10001]', 'Commerce')
+        validation_suggestions = fake_mantis.jira.validate_input('cf[10001]', 'Commerce')
         assert validation_suggestions[0].display_name == 'E-Commerce Checkout Team'
         captured = capsys.readouterr()
         assert captured.out == ('Single match found for cf[10001] "Commerce":\n- E-Commerce Checkout Team (abc123)\n')
         assert captured.err == ""
 
-    def test_validate_input_returns_multiple_suggestion(self, fake_jira: JiraClient, requests_mock, capsys):
-        url = f'{fake_jira.mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=cf[10001]&fieldValue=Commerce'
+    def test_validate_input_returns_multiple_suggestion(self, fake_mantis: MantisClient, requests_mock, capsys):
+        url = f'{fake_mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=cf[10001]&fieldValue=Commerce'
         entry_1 = {'value': 'abc123', 'displayName': 'E-<b>Commerce</b> Checkout Team'}
         entry_2 = {'value': 'abc124', 'displayName': 'E-<b>Commerce</b> Checkin Team'}
         return_value = {'results': [entry_1, entry_2]}
         requests_mock.get(url, json=return_value)
-        validation_suggestions = fake_jira.validate_input('cf[10001]', 'Commerce')
+        validation_suggestions = fake_mantis.jira.validate_input('cf[10001]', 'Commerce')
         assert validation_suggestions[0].display_name == 'E-Commerce Checkout Team'
         assert validation_suggestions[1].display_name == 'E-Commerce Checkin Team'
         captured = capsys.readouterr()
@@ -122,11 +121,11 @@ class TestJiraClient:
             '- E-Commerce Checkin Team (abc124)\n')
         assert captured.err == ""
 
-    def test_validate_input_returns_no_suggestions(self, fake_jira: JiraClient, requests_mock, capsys):
-        url = f'{fake_jira.mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=cf[10001]&fieldValue=Freeloader'
+    def test_validate_input_returns_no_suggestions(self, fake_mantis: MantisClient, requests_mock, capsys):
+        url = f'{fake_mantis.http.api_url}/jql/autocompletedata/suggestions?fieldName=cf[10001]&fieldValue=Freeloader'
         return_value: dict[str, list[dict]] = {'results': []}
         requests_mock.get(url, json=return_value)
-        validation_suggestions = fake_jira.validate_input('cf[10001]', 'Freeloader')
+        validation_suggestions = fake_mantis.jira.validate_input('cf[10001]', 'Freeloader')
         assert len(validation_suggestions) == 0
         captured = capsys.readouterr()
         assert captured.out == 'No results found for cf[10001] "Freeloader"\n'

--- a/tests/test_jira_config_loader.py
+++ b/tests/test_jira_config_loader.py
@@ -1,58 +1,58 @@
 import json
 import pytest
 
-from mantis.jira import JiraClient
+from mantis.mantis_client import MantisClient
 from tests.data import get_issuetypes_response, update_projects_cache_response, CacheData
 
 
-def list_system_cache_contents(fake_jira: JiraClient) -> set[str]:
-        return {str(_).split('/')[-1] for _ in fake_jira.mantis.cache.system.iterdir()}
+def list_system_cache_contents(fake_jira: MantisClient) -> set[str]:
+        return {str(_).split('/')[-1] for _ in fake_jira.cache.system.iterdir()}
 
 
 class TestConfigLoader:
-    def test_config_loader_update_issuetypes_writes_to_cache(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=get_issuetypes_response)
+    def test_config_loader_update_issuetypes_writes_to_cache(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=get_issuetypes_response)
 
-        set_with_no_issuetypes = list_system_cache_contents(fake_jira)
+        set_with_no_issuetypes = list_system_cache_contents(fake_mantis)
         assert set_with_no_issuetypes == {'createmeta', 'editmeta', 'createmeta_schemas', 'editmeta_schemas'}, (
             f"System cache expected 2 values. Got: {set_with_no_issuetypes}")
 
-        fake_jira.system_config_loader.get_issuetypes(force_skip_cache = True)
-        set_with_issuetypes = list_system_cache_contents(fake_jira)
+        fake_mantis.jira.system_config_loader.get_issuetypes(force_skip_cache = True)
+        set_with_issuetypes = list_system_cache_contents(fake_mantis)
         assert set_with_issuetypes == {'createmeta', 'editmeta', 'createmeta_schemas', 'issuetypes.json', 'editmeta_schemas'}, (
-            f"System cache expected 3 values. Got: {fake_jira.mantis.cache.system}")
+            f"System cache expected 3 values. Got: {fake_mantis.cache.system}")
 
-    def test_config_loader_loop_yields_files(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=get_issuetypes_response)
-        assert len(list(fake_jira.system_config_loader.loop_createmeta())) == 0
+    def test_config_loader_loop_yields_files(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=get_issuetypes_response)
+        assert len(list(fake_mantis.jira.system_config_loader.loop_createmeta())) == 0
         # cache something
-        with open(fake_jira.mantis.cache.createmeta / f"some_file.json", "w") as f:
+        with open(fake_mantis.cache.createmeta / f"some_file.json", "w") as f:
             f.write("{}")
-        assert len(list(fake_jira.system_config_loader.loop_createmeta())) == 1
+        assert len(list(fake_mantis.jira.system_config_loader.loop_createmeta())) == 1
 
-    def test_update_project_data(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/project', json=update_projects_cache_response)
+    def test_update_project_data(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/project', json=update_projects_cache_response)
 
         # Test initial state
-        if (fake_jira.mantis.cache.system / 'projects.json').exists():
+        if (fake_mantis.cache.system / 'projects.json').exists():
             raise FileExistsError('File "projects.json" should not exist yet')
-        assert fake_jira._project_id == None
+        assert fake_mantis.jira._project_id == None
 
         # Fetch and cache projects data (without updating the object)
-        got_projects = fake_jira.system_config_loader.get_projects(force_skip_cache = True)
+        got_projects = fake_mantis.jira.system_config_loader.get_projects(force_skip_cache = True)
         assert isinstance(got_projects, list)
         assert len(got_projects) == 2
         assert {_['id'] for _ in got_projects} == {'10000', '10001'}
 
         # Check side-effect
-        if not (fake_jira.mantis.cache.system / 'projects.json').exists():
+        if not (fake_mantis.cache.system / 'projects.json').exists():
             raise FileNotFoundError('File "projects.json" should have been created')
         
         # Note: Private jira._project_id is still None, even after the file has been written.
-        assert fake_jira._project_id == None
+        assert fake_mantis.jira._project_id == None
         # Note: Only once the public jira.project_id is queried does the private one get updated
-        assert fake_jira.project_id == '10000'
-        assert fake_jira._project_id == '10000'
+        assert fake_mantis.jira.project_id == '10000'
+        assert fake_mantis.jira._project_id == '10000'
         
         # Test projects response
         got_project_ids_as_ints = {_['id'] for _ in got_projects}
@@ -60,45 +60,45 @@ class TestConfigLoader:
             'We expect two projects in len(update_projects_cache_response): '
             f'{len(update_projects_cache_response)} Got {got_project_ids_as_ints}')
 
-    def test_update_issuetypes_data(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=CacheData().issuetypes)
+    def test_update_issuetypes_data(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=CacheData().issuetypes)
 
         # Fetch and cache issuetypes data
-        if (fake_jira.mantis.cache.system / 'issuetypes.json').exists():
+        if (fake_mantis.cache.system / 'issuetypes.json').exists():
             raise FileExistsError('File "issuetypes.json" should not exist yet')
         
-        got_issuetypes = fake_jira.system_config_loader.get_issuetypes()
+        got_issuetypes = fake_mantis.jira.system_config_loader.get_issuetypes()
         assert isinstance(got_issuetypes, dict)
         assert 'issueTypes' in got_issuetypes
         assert isinstance(got_issuetypes['issueTypes'], list)
 
-        expected_issue_ids: set[int] = set(map(str, list(range(10001, 10006))))
+        expected_issue_ids: set[str] = set(map(str, list(range(10001, 10006))))
         got_issue_ids_as_ints = {_['id'] for _ in got_issuetypes['issueTypes']}
 
         assert len(got_issuetypes['issueTypes']) == 5, f'Expected 5 issueTypes. Got {len(got_issuetypes)}: {got_issuetypes}'
         assert got_issue_ids_as_ints == expected_issue_ids
-        if not (fake_jira.mantis.cache.system / 'issuetypes.json').exists():
+        if not (fake_mantis.cache.system / 'issuetypes.json').exists():
             raise FileNotFoundError('File "issuetypes.json" should have been created')
 
     @pytest.mark.slow
-    def test_update_createmeta(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=CacheData().issuetypes)
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10001', json=CacheData().createmeta_epic)
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10002', json=CacheData().createmeta_subtask)
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10003', json=CacheData().createmeta_task)
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10004', json=CacheData().createmeta_story)
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10005', json=CacheData().createmeta_bug)
+    def test_update_createmeta(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes', json=CacheData().issuetypes)
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10001', json=CacheData().createmeta_epic)
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10002', json=CacheData().createmeta_subtask)
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10003', json=CacheData().createmeta_task)
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10004', json=CacheData().createmeta_story)
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/TEST/issuetypes/10005', json=CacheData().createmeta_bug)
 
-        if (fake_jira.mantis.cache.createmeta / 'createmeta_story.json').exists():
+        if (fake_mantis.cache.createmeta / 'createmeta_story.json').exists():
             raise FileExistsError('File "createmeta_story.json" should not exist yet')
-        allowed_types = fake_jira.system_config_loader.fetch_and_update_all_createmeta()
-        if not (fake_jira.mantis.cache.createmeta / 'createmeta_story.json').exists():
+        allowed_types = fake_mantis.jira.system_config_loader.fetch_and_update_all_createmeta()
+        if not (fake_mantis.cache.createmeta / 'createmeta_story.json').exists():
             raise FileNotFoundError('File "createmeta_story.json" should have been created')
         
         assert set(allowed_types) == set(['Epic', 'Subtask', 'Task', 'Story', 'Bug'])
 
         def get_allowed_issuetype_name(filename):
-            with open(fake_jira.mantis.cache.createmeta / filename, "r") as f:
+            with open(fake_mantis.cache.createmeta / filename, "r") as f:
                 createmeta_story = json.load(f)
             issuetype = [field for field in createmeta_story["fields"] if field['key'] == 'issuetype'][0]
             return issuetype['allowedValues'][0]['name']
@@ -110,13 +110,13 @@ class TestConfigLoader:
         assert get_allowed_issuetype_name("createmeta_bug.json") == 'Bug'
 
     @pytest.mark.slow
-    def test_compile_plugins(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/project', json={"name": "Testtype"})
-        assert str(fake_jira.mantis.plugins_dir) != ".jira_cache_test"
+    def test_compile_plugins(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/project', json={"name": "Testtype"})
+        assert str(fake_mantis.plugins_dir) != ".jira_cache_test"
 
-        with open(fake_jira.mantis.cache.createmeta / "Testtype.json", "w") as f:
+        with open(fake_mantis.cache.createmeta / "Testtype.json", "w") as f:
             f.write('{"name": "Testtype"}')
 
-        assert (len(list(fake_jira.mantis.plugins_dir.iterdir())) == 0), f"Not empty: {fake_jira.mantis.plugins_dir}"
-        fake_jira.system_config_loader.compile_plugins()
-        assert len(list(fake_jira.mantis.plugins_dir.iterdir())) == 1
+        assert (len(list(fake_mantis.plugins_dir.iterdir())) == 0), f"Not empty: {fake_mantis.plugins_dir}"
+        fake_mantis.jira.system_config_loader.compile_plugins()
+        assert len(list(fake_mantis.plugins_dir.iterdir())) == 1

--- a/tests/test_jira_drafts.py
+++ b/tests/test_jira_drafts.py
@@ -1,34 +1,34 @@
 import pytest
 
-from mantis.jira import JiraClient
 from mantis.jira.jira_issues import JiraIssue
+from mantis.mantis_client import MantisClient
 from tests.data import CacheData
 
 
 class TestJiraDraft:
-    def test_jira_draft(self, fake_jira: JiraClient, minimal_issue_payload, requests_mock):
+    def test_jira_draft(self, fake_mantis: MantisClient, minimal_issue_payload, requests_mock):
         ecs_1 = CacheData().ecs_1
         ecs_1['fields']['assignee'] = {"displayName": "Bobby Goodsky"}
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-1', json=ecs_1)
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-2', json=CacheData().ecs_2)
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-1', json=ecs_1)
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-2', json=CacheData().ecs_2)
 
         minimal_issue_payload['fields']['assignee'] = {"displayName": "Bobby Goodsky"}
-        assert str(fake_jira.mantis.cache.root) != ".jira_cache_test"
-        assert str(fake_jira.mantis.drafts_dir) != "drafts_test"
+        assert str(fake_mantis.cache.root) != ".jira_cache_test"
+        assert str(fake_mantis.drafts_dir) != "drafts_test"
         
-        assert len(list(fake_jira.mantis.drafts_dir.iterdir())) == 0
-        task_1 = fake_jira.issues.get("ECS-1")
-        assert len([*fake_jira.mantis.drafts_dir.iterdir()]) == 1
+        assert len(list(fake_mantis.drafts_dir.iterdir())) == 0
+        task_1 = fake_mantis.jira.issues.get("ECS-1")
+        assert len([*fake_mantis.drafts_dir.iterdir()]) == 1
         assert isinstance(task_1, JiraIssue)
 
         minimal_issue_payload['key'] = "ECS-2"
-        task_2 = fake_jira.issues.get("ECS-2")
-        assert len([*fake_jira.mantis.drafts_dir.iterdir()]) == 2
+        task_2 = fake_mantis.jira.issues.get("ECS-2")
+        assert len([*fake_mantis.drafts_dir.iterdir()]) == 2
 
-        with open(fake_jira.mantis.drafts_dir / "ECS-1.md", "r") as f:
+        with open(fake_mantis.drafts_dir / "ECS-1.md", "r") as f:
             content = f.read()
         assert "assignee: Bobby Goodsky" in content
-        assert "Bobby Goodsky" == fake_jira.issues.get('ECS-1').draft.issue.get_field("assignee", {}).get(
+        assert "Bobby Goodsky" == fake_mantis.jira.issues.get('ECS-1').draft.issue.get_field("assignee", {}).get(
             "displayName", ""
         )
         expectations = (
@@ -48,15 +48,15 @@ class TestJiraDraft:
             "",
             "Implement user authentication for the checkout system.",
         )
-        with open(fake_jira.mantis.drafts_dir / "ECS-1.md", "r") as f:
+        with open(fake_mantis.drafts_dir / "ECS-1.md", "r") as f:
             for content in f.readlines():
                 assert content.strip() in expectations, f"content.strip() ({[content.strip()]}) not in expectations in:\n\t{expectations}"
 
-    def test_read_draft(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
+    def test_read_draft(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
 
         issue_key = 'ECS-1'
-        issue = fake_jira.issues.get(key=issue_key)
+        issue = fake_mantis.jira.issues.get(key=issue_key)
         draft_data = issue.draft.read_draft()
         assert draft_data
         assert draft_data.content == "Implement user authentication for the checkout system."
@@ -75,11 +75,11 @@ class TestJiraDraft:
         draft_field = draft_data.get('summary', 'N/A')
         assert extracted_from_issue_field == draft_field
 
-    def test_read_content(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
+    def test_read_content(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
 
         issue_key = 'ECS-1'
-        issue = fake_jira.issues.get(key=issue_key)
+        issue = fake_mantis.jira.issues.get(key=issue_key)
         draft_content = issue.draft.content
         assert isinstance(draft_content, str)
         assert draft_content == "Implement user authentication for the checkout system."

--- a/tests/test_jira_inspector.py
+++ b/tests/test_jira_inspector.py
@@ -3,9 +3,9 @@ import pytest
 
 from typing import Any
 
-from mantis.jira import JiraClient
 from mantis.cache import CacheMissException
 from mantis.jira.config_loader.config_loader import Inspector
+from mantis.mantis_client import MantisClient
 from tests.data import CacheData
 
 
@@ -34,12 +34,12 @@ class TestInspector:
             Inspector.print_table(["non-existent"], {"placeholder"}, issuetype_field_map)
 
     @pytest.mark.slow
-    def test_get_project_field_keys_from_cache(self, fake_jira: JiraClient):
-        fake_jira.issues._allowed_types = ["Test"] # To avoid calling load_allowed_types
+    def test_get_project_field_keys_from_cache(self, fake_mantis: MantisClient):
+        fake_mantis.jira.issues._allowed_types = ["Test"] # To avoid calling load_allowed_types
         with pytest.raises(CacheMissException):
-            Inspector.get_createmeta_models(fake_jira)
+            Inspector.get_createmeta_models(fake_mantis.jira)
 
-        with open(fake_jira.mantis.cache.createmeta / "createmeta_test.json", "w") as f:
+        with open(fake_mantis.cache.createmeta / "createmeta_test.json", "w") as f:
             json.dump(CacheData().createmeta_epic, f)
-        from_cache = Inspector.get_createmeta_models(fake_jira)
+        from_cache = Inspector.get_createmeta_models(fake_mantis.jira)
         assert from_cache

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -5,23 +5,22 @@ from unittest.mock import Mock, patch
 import pytest
 from requests.models import HTTPError
 
-from mantis.jira import JiraClient
 from mantis.jira.jira_client import process_key
 from mantis.jira.jira_issues import JiraIssues
+from mantis.mantis_client import MantisClient
 from tests.data import CacheData
 
 
 class TestJiraIssues:
-    def test_jira_issues_get_fake(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
+    def test_jira_issues_get_fake(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
 
-        task_1 = fake_jira.issues.get("ECS-1")
+        task_1 = fake_mantis.jira.issues.get("ECS-1")
         assert task_1.get("key") == "ECS-1"
         assert task_1.get("fields", {})["status"]['name'] == "In Progress"
 
-
-    def test_jira_issues_get_mocked(self, fake_jira: JiraClient, with_no_read_cache, minimal_issue_payload):
-        assert fake_jira.mantis._no_read_cache is True
+    def test_jira_issues_get_mocked(self, fake_mantis: MantisClient, with_no_read_cache, minimal_issue_payload):
+        assert fake_mantis._no_read_cache is True
         expected = minimal_issue_payload
         mock_response = Mock()
         mock_response.status_code = 200
@@ -30,12 +29,11 @@ class TestJiraIssues:
         mock_response.headers = {"Content-Type": "text/plain"}
         mock_response.text = "Description"
         with patch("requests.get", return_value=mock_response):
-            task_1 = fake_jira.issues.get("TASK-1")
+            task_1 = fake_mantis.jira.issues.get("TASK-1")
         assert task_1.get("key") == "TASK-1"
         assert task_1.get("fields", {}).get("status") == {"name": "resolved"}
 
-
-    def test_jira_issues_get_non_existent(self, with_no_read_cache, fake_jira: JiraClient):
+    def test_jira_issues_get_non_existent(self, with_no_read_cache, fake_mantis: MantisClient):
         mock_response = Mock()
         mock_response.reason = "Not Found"
         mock_response.raise_for_status.side_effect = HTTPError()
@@ -47,14 +45,14 @@ class TestJiraIssues:
                 ValueError,
                 match=('The issue "TEST-999" does not exists in ' 'the project "TEST"'),
             ):
-                fake_jira.issues.get("TEST-999")
+                fake_mantis.jira.issues.get("TEST-999")
             with pytest.raises(
                 ValueError,
                 match="The requested issue does not exist. Note "
                 'that the provided key "NONEXISTENT-1" does not '
                 'appear to match your configured project "TEST"',
             ):
-                fake_jira.issues.get("NONEXISTENT-1")
+                fake_mantis.jira.issues.get("NONEXISTENT-1")
             with pytest.raises(
                 NotImplementedError,
                 match=(
@@ -62,26 +60,25 @@ class TestJiraIssues:
                     'provide the full key for your issue: "PROJ-11"'
                 ),
             ):
-                fake_jira.issues.get("11")
+                fake_mantis.jira.issues.get("11")
             with pytest.raises(
                 ValueError, match=('Issue number "PROJ" in key "1-PROJ" must ' "be numeric")
             ):
-                fake_jira.issues.get("1-PROJ")
+                fake_mantis.jira.issues.get("1-PROJ")
             with pytest.raises(
                 ValueError,
                 match=re.escape("Whitespace in key is not allowed " '("PROJ-1 ")'),
             ):
-                fake_jira.issues.get("PROJ-1 ")
+                fake_mantis.jira.issues.get("PROJ-1 ")
 
-
-    def test_jira_issues_create(self, fake_jira: JiraClient, minimal_issue_payload, requests_mock):
-        fake_jira.issues._allowed_types = ["Story", "Subtask", "Epic", "Bug", "Task"]
-        requests_mock.post(f'{fake_jira.mantis.http.api_url}/issue', json={})
+    def test_jira_issues_create(self, fake_mantis: MantisClient, minimal_issue_payload, requests_mock):
+        fake_mantis.jira.issues._allowed_types = ["Story", "Subtask", "Epic", "Bug", "Task"]
+        requests_mock.post(f'{fake_mantis.http.api_url}/issue', json={})
         with pytest.raises(ValueError):
-            issue = fake_jira.issues.create(issuetype="Bug", title="Tester", data={})
+            issue = fake_mantis.jira.issues.create(issuetype="Bug", title="Tester", data={})
         minimal_issue_payload['fields']['issuetype']['name'] = 'Bug'
-        requests_mock.post(f'{fake_jira.mantis.http.api_url}/issue', json=minimal_issue_payload)
-        issue = fake_jira.issues.create(
+        requests_mock.post(f'{fake_mantis.http.api_url}/issue', json=minimal_issue_payload)
+        issue = fake_mantis.jira.issues.create(
             issuetype="Bug", title="Tester", data={"Summary": "a"}
         )
         fields = issue.get("fields", {})
@@ -92,7 +89,6 @@ class TestJiraIssues:
         assert name is not None, "Expected 'name' to be present in 'issuetype'"
         assert name == "Bug", "Expected issue type name to be 'Bug'"
 
-
     def test_process_key(self, ):
         with pytest.raises(NotImplementedError):
             try:
@@ -100,9 +96,8 @@ class TestJiraIssues:
             except HTTPError as e:
                 process_key(key="A-B-1", exception=e)
 
-
-    def test_handle_http_error_raises_generic_exception(self, fake_jira: "JiraClient", requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
+    def test_handle_http_error_raises_generic_exception(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
         mock_response = Mock()
         mock_response.reason = "Unknown error"
         mock_response.raise_for_status.side_effect = HTTPError()
@@ -111,23 +106,21 @@ class TestJiraIssues:
         )
         with patch("requests.get", return_value=mock_response):
             try:
-                response = fake_jira.mantis.http._get("Task-3")
+                response = fake_mantis.http._get("Task-3")
                 response.raise_for_status()
             except HTTPError as e:
                 assert e.response.reason == "Unknown error"
                 with pytest.raises(AttributeError):
-                    fake_jira.handle_http_error(exception=e, key="A-1")
+                    fake_mantis.jira.handle_http_error(exception=e, key="A-1")
 
-
-    def test_jira_no_issues_fields_raises(self, fake_jira: JiraClient, requests_mock):
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
-        issue = fake_jira.issues.get("ECS-1")
+    def test_jira_no_issues_fields_raises(self, fake_mantis: MantisClient, requests_mock):
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
+        issue = fake_mantis.jira.issues.get("ECS-1")
         issue.data["fields"] = None  # type: ignore since we are purely testing that it raises an error
         with pytest.raises(KeyError):
             assert issue.fields
 
-
-    def test_jira_issues_cached_issuetypes_parses_allowed_types(self, fake_jira: JiraClient):
+    def test_jira_issues_cached_issuetypes_parses_allowed_types(self, fake_mantis: MantisClient):
         cached_issuetypes = {
             "issueTypes": [
                 {"id": '1', "name": "Bug", 'scope': {'project': {'id': '10000'}}},
@@ -135,25 +128,24 @@ class TestJiraIssues:
             ]
         }
         with patch('mantis.jira.config_loader.JiraSystemConfigLoader.get_issuetypes', return_value=cached_issuetypes):
-            fake_jira.issues = JiraIssues(fake_jira)
-            assert fake_jira.issues._allowed_types is None
-            assert fake_jira.issues.allowed_types == ["Bug", "Task"], f'Unexpected allowed types: {fake_jira.issues._allowed_types}'
-            assert fake_jira.issues._allowed_types
+            fake_mantis.jira.issues = JiraIssues(fake_mantis.jira)
+            assert fake_mantis.jira.issues._allowed_types is None
+            assert fake_mantis.jira.issues.allowed_types == ["Bug", "Task"], f'Unexpected allowed types: {fake_mantis.jira.issues._allowed_types}'
+            assert fake_mantis.jira.issues._allowed_types
 
-    def test_jira_issues_get_does_write_to_cache(self, fake_jira: JiraClient, requests_mock):
-        assert fake_jira.mantis.cache.get_issue("ECS-1") is None
-        requests_mock.get(f'{fake_jira.mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
-        issue = fake_jira.issues.get("ECS-1")
-        assert fake_jira.mantis.cache.get_issue("ECS-1")
-        assert len([file for file in fake_jira.mantis.cache.issues.iterdir()]) == 1
-        with open(fake_jira.mantis.cache.issues / "ECS-1.json", "r") as f:
+    def test_jira_issues_get_does_write_to_cache(self, fake_mantis: MantisClient, requests_mock):
+        assert fake_mantis.cache.get_issue("ECS-1") is None
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/ECS-1', json=CacheData().ecs_1)
+        issue = fake_mantis.jira.issues.get("ECS-1")
+        assert fake_mantis.cache.get_issue("ECS-1")
+        assert len([file for file in fake_mantis.cache.issues.iterdir()]) == 1
+        with open(fake_mantis.cache.issues / "ECS-1.json", "r") as f:
             data = json.load(f)
         assert data["key"] == "ECS-1"
 
-
-    def test_jira_issues_get_does_retrieve_from_cache(self, fake_jira: JiraClient, minimal_issue_payload):
-        fake_jira.mantis._no_read_cache = False
-        with open(fake_jira.mantis.cache.issues / "TASK-1.json", "w") as f:
+    def test_jira_issues_get_does_retrieve_from_cache(self, fake_mantis: MantisClient, minimal_issue_payload):
+        fake_mantis._no_read_cache = False
+        with open(fake_mantis.cache.issues / "TASK-1.json", "w") as f:
             json.dump(minimal_issue_payload, f)
-        issue = fake_jira.issues.get("TASK-1")
+        issue = fake_mantis.jira.issues.get("TASK-1")
         assert issue.get_field("summary") == "redacted"


### PR DESCRIPTION
Tests were originally built around the `fake_jira` object. Now that `Mantis` is the central entry point, center the tests around `fake_mantis` instead.