### PR TITLE
Fix: Let draft template be loaded as a Python file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.2.5"
+version = "0.2.6"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}

--- a/src/drafts/__init__.py
+++ b/src/drafts/__init__.py
@@ -1,3 +1,5 @@
+from .template_md import template
+
 from pathlib import Path
 import re
 from typing import Any, Callable, TYPE_CHECKING, Generator
@@ -19,7 +21,7 @@ class Draft:
         assert self.mantis.drafts_dir
         self.issue = issue
         self.summary = self.issue.get_field("summary", "")
-        assert self._required_frontmatter == ['header', 'project', 'parent', 'summary', 'status', 'issuetype', 'assignee', 'reporter']
+        assert self._required_frontmatter == ['header', 'project', 'parent', 'summary', 'status', 'issuetype', 'assignee', 'reporter'], f'Unexpected required frontmatter: {self._required_frontmatter}'
         self._materialize()
 
     @property
@@ -42,8 +44,7 @@ class Draft:
         return list(self.template.metadata.keys())
 
     def _load_template(self) -> frontmatter.Post:
-        with open('src/drafts/template.md', 'r') as f:
-            return frontmatter.load(f)
+        return frontmatter.loads(template)
 
     def _generate_frontmatter(self) -> None:
         for field_name in self._required_frontmatter:

--- a/src/drafts/template_md.py
+++ b/src/drafts/template_md.py
@@ -1,3 +1,4 @@
+template ='''\
 ---
 header: "Will be set dynamically"
 project: {project}
@@ -12,3 +13,4 @@ reporter: {reporter}
 
 {description}
 
+'''


### PR DESCRIPTION
Since we are aiming for being able to run the CLI anywhere, the draft template needs to make sure the template can be read. Ideally, the content should be configurable client side, but for now we'll just import it as a Python file, so the content is at least loading.