### PR TITLE
New action "new"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Overwrite description of issue [TASK-1] "Setup Jira with style"? (y/n): y
 Updating description with data: ({'description': 'Setup Jira with style'})
 Reloading TASK-1
 
+# Create a new issue. First argument is a type (task|story|bug|epic), the rest get concatenated into a title.
+$ mantis new epic A new epic title
+Creating issue (epic): A new epic title
+{'id': '10033',
+ 'key': 'TASK-7',
+ 'self': 'https://testaccount.atlassian.net/rest/api/latest/issue/10033'}
+Created issue: [TASK-7]
+Reloading TASK-7
+
 # Re-fetches config files
 $ mantis reset
 ['Epic', 'Subtask', 'Task', 'Story', 'Bug']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.2.12"
+version = "0.2.13"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ def main() -> None:
         x = jira.system_config_loader.get_issuetypes()
         pprint (x)
     elif options.action == 'get-issue':
-        for issue_key in options.issues:
+        for issue_key in options.args:
             issue = jira.issues.get(key=issue_key)
             key = issue.get('key', 'N/A')
             title = issue.get_field('summary')
@@ -40,7 +40,7 @@ def main() -> None:
 
         validated_input = jira.validate_input(search_field, search_name)
     elif options.action == 'update-issue':
-        for issue_key in options.issues:
+        for issue_key in options.args:
             issue = jira.issues.get(key=issue_key)
             data = {
                 "fields": {
@@ -56,7 +56,7 @@ def main() -> None:
             print(f'[{key}] {title}')
             mantis._no_read_cache = False
     elif options.action == 'compare':
-        for issue_key in options.issues:
+        for issue_key in options.args:
             issue = jira.issues.get(key=issue_key)
             print(f'Type: {issue.issuetype}')
             draft_data = issue.draft.read_draft()
@@ -102,7 +102,7 @@ def main() -> None:
             print(f'{'create':^10} {'edit':^10} {'issue':^10} {'draft':^10} {'creat_fact':^10} {'edit_fact':^10}')
 
     elif options.action == 'view-key':
-        for issue_key in options.issues:
+        for issue_key in options.args:
             issue = jira.issues.get(key=issue_key)
             draft_data = issue.draft.read_draft()
 
@@ -150,16 +150,16 @@ def main() -> None:
         auto_complete_suggestions = jira.auto_complete.get_suggestions("reporter", 'Casper')
         print(auto_complete_suggestions)
     elif options.action == 'check-field':
-        for issue_key in options.issues:
+        for issue_key in options.args:
             issue = jira.issues.get(key=issue_key)
             field = IssueField(issue, 'assignee')
             field.check_field()
     elif options.action == 'update-issue-from-draft':
-        for issue_key in options.issues:
+        for issue_key in options.args:
             issue = jira.issues.get(key=issue_key)
             issue.update_from_draft()
     elif options.action == 'diff-issue-from-draft':
-        for issue_key in options.issues:
+        for issue_key in options.args:
             issue = jira.issues.get(key=issue_key)
             issue.diff_issue_from_draft()
     elif options.action == 'get-project-keys':
@@ -212,6 +212,6 @@ def main() -> None:
         jira.web()
     else:
         print(f'Action {options.action} not recognized')
-    
+
 if __name__ == '__main__':
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -208,6 +208,12 @@ def main() -> None:
         data_ = jira.issues.get("ECS-1")
         changes = data_.draft.make_verbose()
         pprint(changes)
+    elif options.action == 'new':
+        issue_type = options.args.pop(0).title() if options.args else 'Task'
+        issue_title = ' '.join(options.args) or f'New {issue_type}'
+        if issue_type not in jira.issues.allowed_types:
+            raise ValueError(f'Issue type {issue_type} is not allowed. Allowed types: {jira.issues.allowed_types}')
+        data = jira.issues.create(issuetype=issue_type, title=issue_title, data={})
     elif options.action == 'open-jira':
         jira.web()
     else:

--- a/src/mantis/http.py
+++ b/src/mantis/http.py
@@ -39,7 +39,6 @@ class Http:
         url = f"{self.api_url}/{uri}"
         return requests.get(url, params=params, **self.requests_kwargs)  # type: ignore
 
-
     @staticmethod
     def post(url: str, data: dict | None = None) -> str:
         """

--- a/src/mantis/jira/jira_client.py
+++ b/src/mantis/jira/jira_client.py
@@ -130,6 +130,7 @@ class JiraClient:
         return issue_data
 
     def post_issue(self, data: dict) -> dict:
+        """Post a new issue to Jira"""
         response = self.mantis.http._post("issue", data=data)
         response.raise_for_status()
         return response.json()

--- a/src/mantis/jira/jira_client.py
+++ b/src/mantis/jira/jira_client.py
@@ -132,7 +132,12 @@ class JiraClient:
     def post_issue(self, data: dict) -> dict:
         """Post a new issue to Jira"""
         response = self.mantis.http._post("issue", data=data)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print(e.response.reason)
+            print(e.response.json())
+            exit()
         return response.json()
 
     def warmup(self, delete_drafts: bool=False) -> None:

--- a/src/mantis/jira/jira_client.py
+++ b/src/mantis/jira/jira_client.py
@@ -86,7 +86,7 @@ class JiraClient:
         issuetypes: dict[str, list[dict[str, Any]]] = response.json()
         assert isinstance(issuetypes, dict), f'issuetypes is not a dict: {issuetypes}'
         assert 'issueTypes' in issuetypes, f"'issueTypes' not in issuetypes. Got keys: {list(issuetypes.keys())}"
-        assert isinstance(issuetypes['issueTypes'], list), "issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
+        assert isinstance(issuetypes['issueTypes'], list), f"issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
         li = issuetypes['issueTypes']
         assert isinstance(li, list), f"issuetypes['issueTypes'] is not a list. Got: {issuetypes}"
         for x in li:

--- a/src/mantis/jira/jira_issues.py
+++ b/src/mantis/jira/jira_issues.py
@@ -111,6 +111,10 @@ class JiraIssue:
         return default if value is None else value
 
     def update_field(self, data: dict[str, Any]) -> None:
+        """Update a field in the issue with the given data
+        
+        https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put
+        """
         self.jira.update_field(self.key, data)
 
     def update_from_draft(self) -> None:
@@ -211,6 +215,10 @@ class JiraIssues:
         return JiraIssue(self.jira, data)
 
     def create(self, issuetype: str, title: str, data: dict) -> dict:
+        """Create a new issue in Jira
+        
+        https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post
+        """
         assert issuetype in self.allowed_types
         if len(data.keys()) == 0:
             raise ValueError("The data object is an empty payload")

--- a/src/mantis/jira/jira_issues.py
+++ b/src/mantis/jira/jira_issues.py
@@ -220,10 +220,18 @@ class JiraIssues:
         https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post
         """
         assert issuetype in self.allowed_types
-        if len(data.keys()) == 0:
-            raise ValueError("The data object is an empty payload")
-        print(f"Create issue ({issuetype}): {title}")
-
-        response = self.jira.post_issue(data)
+        issuetype_id = self.jira.issuetype_name_to_id(issuetype)
+        if 'issuetype' not in data:
+            data['issuetype'] = {'id': issuetype_id}
+        if 'summary' not in data:
+            data['summary'] = title
+        data['project'] = {'id': self.jira.project_id}
+        assert title == data['summary'], 'The "title" parameter must match the "summary" in the data object'
+        print(f"Creating issue ({issuetype}): {title}")
+        response = self.jira.post_issue({'fields': data})
+        issue_key = response["key"]
+        print(f'Created issue: [{issue_key}]')
         pprint(response)
+        print(f'Reloading {issue_key}')
+        self.get(issue_key).reload_issue()
         return response

--- a/src/mantis/options_loader.py
+++ b/src/mantis/options_loader.py
@@ -163,7 +163,7 @@ class OptionsLoader:
         return self.parser and self.parser.action or ""
 
     @property
-    def issues(self) -> list[str]:
+    def args(self) -> list[str]:
         return self.parser and self.parser.issues or []
     
 

--- a/src/mantis/options_loader.py
+++ b/src/mantis/options_loader.py
@@ -165,7 +165,6 @@ class OptionsLoader:
     @property
     def args(self) -> list[str]:
         return self.parser and self.parser.issues or []
-    
 
 
 def parse_args(args_overwrite: list[str] | None = None) -> argparse.Namespace:

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -77,8 +77,6 @@ class TestJiraIssues:
         requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/{fake_mantis.jira.project_name}/issuetypes', json={'issueTypes': [{'id': '10001', 'name': 'Bug'}]})
         requests_mock.get(f'{fake_mantis.http.api_url}/project', json=[{'key': 'TEST', 'id': '1'}])
         requests_mock.get(f'{fake_mantis.http.api_url}/issue/TASK-1', json={'key': 'TASK-1', 'fields': minimal_issue_payload['fields']})
-        with pytest.raises(ValueError):
-            issue = fake_mantis.jira.issues.create(issuetype="Bug", title="Tester", data={})
         minimal_issue_payload['fields']['issuetype']['name'] = 'Bug'
         requests_mock.post(f'{fake_mantis.http.api_url}/issue', json=minimal_issue_payload)
         issue = fake_mantis.jira.issues.create(

--- a/tests/test_jira_issues.py
+++ b/tests/test_jira_issues.py
@@ -73,7 +73,10 @@ class TestJiraIssues:
 
     def test_jira_issues_create(self, fake_mantis: MantisClient, minimal_issue_payload, requests_mock):
         fake_mantis.jira.issues._allowed_types = ["Story", "Subtask", "Epic", "Bug", "Task"]
-        requests_mock.post(f'{fake_mantis.http.api_url}/issue', json={})
+        requests_mock.post(f'{fake_mantis.http.api_url}/issue', json={'key': 'TASK-1'})
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/createmeta/{fake_mantis.jira.project_name}/issuetypes', json={'issueTypes': [{'id': '10001', 'name': 'Bug'}]})
+        requests_mock.get(f'{fake_mantis.http.api_url}/project', json=[{'key': 'TEST', 'id': '1'}])
+        requests_mock.get(f'{fake_mantis.http.api_url}/issue/TASK-1', json={'key': 'TASK-1', 'fields': minimal_issue_payload['fields']})
         with pytest.raises(ValueError):
             issue = fake_mantis.jira.issues.create(issuetype="Bug", title="Tester", data={})
         minimal_issue_payload['fields']['issuetype']['name'] = 'Bug'


### PR DESCRIPTION
Introduce `mantis new` for creating new issues.

First argument is a type: Either of `task`, `story`, `bug`, `epic` (`subtasks` not considered yet).

The rest get concatenated into a title, i.e. it gets parsed like this:
- `mantis new epic A new epic title`: `mantis` `new` `epic` `A new epic title`

```sh
$ mantis new epic A new epic title
Creating issue (epic): A new epic title
{'id': '10033',
 'key': 'TASK-7',
 'self': 'https://testaccount.atlassian.net/rest/api/latest/issue/10033'}
Created issue: [TASK-7]
Reloading TASK-7
```