### PR TITLE
Fix Dependabot package manager type

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,0 +1,42 @@
+# Copilot Usage Instructions
+
+## Overview
+This project supports GitHub Copilot and Copilot Chat for code suggestions, documentation, and automation. Follow these guidelines to get the most out of Copilot in this repository.
+
+## Best Practices
+- **Write clear, descriptive comments and docstrings** to help Copilot understand your intent.
+- **Use type hints** and explicit variable names for better suggestions.
+- **Break down complex problems** into smaller functions or classes for more accurate completions.
+- **Review Copilot suggestions** for correctness, security, and style before accepting.
+
+## Common Tasks
+- **Generate tests:**
+  - Write a function or class, then type `# test` or `# pytest` below it to get test suggestions.
+- **Refactor code:**
+  - Select code and ask Copilot Chat for refactoring or optimization tips.
+- **Documentation:**
+  - Type `# docstring` or `# documentation` above a function/class for docstring suggestions.
+- **Regex and formatting:**
+  - Ask Copilot Chat for help with regular expressions or string formatting best practices.
+
+## Project-Specific Tips
+- **Poetry:**
+  - Copilot can help with dependency management and `pyproject.toml` edits.
+- **Pytest:**
+  - Use Copilot to generate fixtures, parameterized tests, and test utilities.
+- **Jira/Mantis CLI:**
+  - Ask Copilot for CLI usage examples, config file templates, or integration patterns.
+
+## Limitations
+- Copilot does not automatically bump your project version or handle release automation. Use GitHub Actions or manual steps for versioning.
+- Always review Copilot’s code for project-specific conventions and security.
+
+## Getting Help
+- Use Copilot Chat for:
+  - Explaining code
+  - Debugging errors
+  - Generating documentation
+  - Exploring best practices
+
+---
+For more, see the [GitHub Copilot documentation](https://docs.github.com/en/copilot).

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,42 +1,20 @@
-# Copilot Usage Instructions
+# Copilot PR Review Instructions
 
-## Overview
-This project supports GitHub Copilot and Copilot Chat for code suggestions, documentation, and automation. Follow these guidelines to get the most out of Copilot in this repository.
+As Copilot, when reviewing pull requests in this repository, follow these guidelines:
 
-## Best Practices
-- **Write clear, descriptive comments and docstrings** to help Copilot understand your intent.
-- **Use type hints** and explicit variable names for better suggestions.
-- **Break down complex problems** into smaller functions or classes for more accurate completions.
-- **Review Copilot suggestions** for correctness, security, and style before accepting.
+- Enforce code style and formatting consistent with the project.
+- Ensure all new and modified code is covered by appropriate tests.
+- Check that all public functions, classes, and modules have clear docstrings.
+- Verify that changes do not break existing functionality or tests.
+- Confirm that dependency updates (if any) are justified and safe.
+- For CLI or config changes, ensure documentation and usage examples are updated.
+- For Python code, prefer type hints and explicit error handling.
+- For Poetry projects, ensure `pyproject.toml` and `poetry.lock` are consistent.
+- For pytest, check that fixtures are used efficiently and test isolation is maintained.
+- Flag any security, performance, or maintainability concerns.
+- If the PR description is unclear or missing context, request clarification.
 
-## Common Tasks
-- **Generate tests:**
-  - Write a function or class, then type `# test` or `# pytest` below it to get test suggestions.
-- **Refactor code:**
-  - Select code and ask Copilot Chat for refactoring or optimization tips.
-- **Documentation:**
-  - Type `# docstring` or `# documentation` above a function/class for docstring suggestions.
-- **Regex and formatting:**
-  - Ask Copilot Chat for help with regular expressions or string formatting best practices.
-
-## Project-Specific Tips
-- **Poetry:**
-  - Copilot can help with dependency management and `pyproject.toml` edits.
-- **Pytest:**
-  - Use Copilot to generate fixtures, parameterized tests, and test utilities.
-- **Jira/Mantis CLI:**
-  - Ask Copilot for CLI usage examples, config file templates, or integration patterns.
-
-## Limitations
-- Copilot does not automatically bump your project version or handle release automation. Use GitHub Actions or manual steps for versioning.
-- Always review Copilot’s code for project-specific conventions and security.
-
-## Getting Help
-- Use Copilot Chat for:
-  - Explaining code
-  - Debugging errors
-  - Generating documentation
-  - Exploring best practices
+If any of these guidelines are not met, leave a constructive comment or request changes.
 
 ---
-For more, see the [GitHub Copilot documentation](https://docs.github.com/en/copilot).
+These instructions are for Copilot and Copilot Chat PR review automation only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.3.2"
+version = "0.3.3"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}


### PR DESCRIPTION
>Your .github/dependabot.yml contained invalid details
Dependabot encountered the following error when parsing your .github/dependabot.yml:
>
> The property '#/updates/0/package-ecosystem' value "poetry" did not match one of the following values: npm, bundler, composer, devcontainers, dotnet-sdk, maven, mix, cargo, gradle, nuget, gomod, docker, docker-compose, elm, gitsubmodule, github-actions, pip, terraform, pub, swift, bun, uv, helm
Please update the config file to conform with Dependabot's specification.
>
>Details
>For more info on the config file format, see [the config file documentation](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml)