### PR TITLE
Retry fix Dependabot package manager type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "poetry"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI for locally managing Jira issues"
 authors = [
     {name = "casperlehmann",email = "6682833+casperlehmann@users.noreply.github.com"}


### PR DESCRIPTION
Retry #149.

>Your .github/dependabot.yml contained invalid details
Dependabot encountered the following error when parsing your .github/dependabot.yml:
>
> The property '#/updates/0/package-ecosystem' value "poetry" did not match one of the following values: npm, bundler, composer, devcontainers, dotnet-sdk, maven, mix, cargo, gradle, nuget, gomod, docker, docker-compose, elm, gitsubmodule, github-actions, pip, terraform, pub, swift, bun, uv, helm
Please update the config file to conform with Dependabot's specification.
>
>Details
>For more info on the config file format, see [the config file documentation](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml)

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#configuration-options-for-dependabotyml