### PR TITLE
Change order of checks in _extract_name_from_cached_object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.3.6"
+version = "0.3.7"
 description = "CLI for locally managing Jira issues"
 authors = [{ name = "casperlehmann", email = "6682833+casperlehmann@users.noreply.github.com" }]
 requires-python = "<4.0,>=3.12"

--- a/src/jira/issue_field.py
+++ b/src/jira/issue_field.py
@@ -12,7 +12,6 @@ class IssueField:
 
     def _extract_name_from_cached_object(self) -> Any | None:
         value_from_cache = self.issue.get_field(self.key)
-        assert self.editmeta_type == self.createmeta_type
         if value_from_cache is None:
             #raise ValueError(f'value_from_cache is None for key: {self.key}')
             return None
@@ -29,7 +28,9 @@ class IssueField:
             raise ValueError(
                 f"Both editmeta_type and createmeta_type are N/A. This field ('{self.key}') probably shouldn't be updated like this. editmeta_type: '{self.editmeta_type}'. createmeta_type: '{self.createmeta_type}'.")
         elif self.editmeta_type == 'N/A' or self.createmeta_type == 'N/A':
-            raise NotImplementedError(f"editmeta_type == 'N/A' or createmeta_type == 'N/A' for '{self.key}'")
+            raise NotImplementedError(f"editmeta_type ({self.editmeta_type}) or createmeta_type ({self.createmeta_type}) is 'N/A' for '{self.key}'")
+        elif self.editmeta_type != self.createmeta_type:
+            raise ValueError(f'editmeta_type ({self.editmeta_type}) and createmeta_type ({self.createmeta_type}) are not equal for key: {self.key}')
         else:
             return value_from_cache.get('name')
 

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "mantis"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
Change order of checks to allow reaching check of `self.editmeta_type == 'N/A' or self.createmeta_type == 'N/A'`.