### PR TITLE
Bump version to "0.3.17"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mantis"
-version = "0.3.16"
+version = "0.3.17"
 description = "CLI for locally managing Jira issues"
 authors = [{ name = "casperlehmann", email = "6682833+casperlehmann@users.noreply.github.com" }]
 requires-python = "<4.0,>=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "mantis"
-version = "0.3.16"
+version = "0.3.17"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
Release process in #174 didn't update files. This updates `pyproject.toml` and `uv.lock`.