### PR TITLE
Use PAT for creating releases PRs to allow running CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
+        env:
+            GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/bump-v${{ steps.new_version.outputs.version }}


### PR DESCRIPTION
PRs that are created using the `github-actions[bot]` will (ironically) not execute GitHub Actions. See discussion here: https://github.com/peter-evans/create-pull-request/issues/48

This means that required checks may be stuck waiting on actions to run, e.g. `build Expected — Waiting for status to be reported`:

<img width="816" height="335" alt="Screenshot 2025-07-23 at 17 39 32" src="https://github.com/user-attachments/assets/472b6e65-3783-4777-90a7-eb9093977395" />

As a workaround, we can add a PAT which means triggering as a user, not as a bot. Therefore we don't have this limitation.

```yml
      env:
        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
```
