### PR TITLE
Fix: Change secrets.GITHUB_TOKEN to env.GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ env.GITHUB_TOKEN }}
           branch: release/bump-v${{ steps.new_version.outputs.version }}
           title: "Bump version to v${{ steps.new_version.outputs.version }}"
           commit-message: "Bump version to v${{ steps.new_version.outputs.version }}"


### PR DESCRIPTION
In #181, forgot to reference the new env var for GitHub Token in release process.