### PR TITLE
Set git user in validate_bump

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -109,6 +109,8 @@ jobs:
         if: steps.check-pr-type.outputs.allowed == 'true'
         run: |
           set -e
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           echo "Current PR branch: $PR_BRANCH"
           # Get bump type from PR labels


### PR DESCRIPTION
CI job `Validate PR is a clean version bump` got error:

```
mantis 0.3.26 => 0.3.27
Author identity unknown
*** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
Omit --global to set the identity only in this repository.
fatal: empty ident name (for <runner@pkrvmpptgkbjq6m.z215w3z3qktejmvuq2qnpj4cbf.gx.internal.cloudapp.net>) not allowed
M	pyproject.toml
M	uv.lock
Your branch is up to date with 'origin/master'.
❌ PR branch does not match a clean version bump from master.
```

Fix by setting git user in worker.