### PR TITLE
Don't delete temp branch in worker

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -137,7 +137,6 @@ jobs:
             echo "✅ PR branch matches a clean version bump from master."
             echo "bump_check=true" >> $GITHUB_OUTPUT
           fi
-          git branch -D _tmp_master
         env:
           PR_NUMBER: ${{ steps.check-pr-type.outputs.pr_number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Don't delete current branch in CI worker to avoid error:

```
mantis 0.3.26 => 0.3.27
[_tmp_master 49b19c7] temp version bump
 2 files changed, 2 insertions(+), 2 deletions(-)
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)
✅ PR branch matches a clean version bump from master.
error: cannot delete branch '_tmp_master' used by worktree at '/home/runner/work/mantis/mantis'
Error: Process completed with exit code 1.
```
