### PR TITLE
Add merge commit message template

### DIFF
--- a/.gitea/default_merge_message/MERGE_TEMPLATE.md
+++ b/.gitea/default_merge_message/MERGE_TEMPLATE.md
@@ -1,0 +1,3 @@
+${PullRequestTitle}
+
+${PullRequestDescription}


### PR DESCRIPTION
Adds `.gitea/default_merge_message/MERGE_TEMPLATE.md` to use the PR title and description as the merge commit message.